### PR TITLE
#1 Feat: 기본 엔티티 생성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,12 +24,12 @@ repositories {
 }
 
 dependencies {
-//	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
 	compileOnly 'org.projectlombok:lombok'
-//	runtimeOnly 'com.mysql:mysql-connector-j'
+	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/src/main/java/com/memesphere/domain/ChartData.java
+++ b/src/main/java/com/memesphere/domain/ChartData.java
@@ -1,0 +1,45 @@
+package com.memesphere.domain;
+
+import com.memesphere.domain.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@DynamicUpdate
+@DynamicInsert
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChartData extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name="chart_id")
+    private Long id;
+
+    @Column
+    private LocalDateTime recorded_time;
+
+    @Column
+    private BigDecimal price;
+
+    @Column
+    private BigDecimal price_change;
+
+    @Column
+    private BigDecimal market_cap;
+
+    @Column
+    private Integer volume;
+
+    @ManyToOne(fetch=FetchType.LAZY)
+    @JoinColumn(name="coin_id")
+    private MemeCoin memeCoin;
+}

--- a/src/main/java/com/memesphere/domain/Chat.java
+++ b/src/main/java/com/memesphere/domain/Chat.java
@@ -1,0 +1,41 @@
+package com.memesphere.domain;
+
+import com.memesphere.domain.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@DynamicUpdate
+@DynamicInsert
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Chat extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name="chat_id")
+    private Long id;
+
+    @Column
+    private String messaeg;
+
+
+    @ManyToOne(fetch=FetchType.LAZY)
+    @JoinColumn(name="user_id")
+    private User user;
+
+    @ManyToOne(fetch=FetchType.LAZY)
+    @JoinColumn(name="coin_id")
+    private MemeCoin memeCoin;
+
+    @OneToMany(mappedBy = "chat", cascade = CascadeType.ALL)
+    private List<ChatLike> chatLikeList = new ArrayList<>();
+}

--- a/src/main/java/com/memesphere/domain/ChatLike.java
+++ b/src/main/java/com/memesphere/domain/ChatLike.java
@@ -1,0 +1,31 @@
+package com.memesphere.domain;
+
+import com.memesphere.domain.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@DynamicUpdate
+@DynamicInsert
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChatLike extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name="like_id")
+    private Long id;
+
+    @ManyToOne(fetch=FetchType.LAZY)
+    @JoinColumn(name="user_id")
+    private User user;
+
+    @ManyToOne(fetch=FetchType.LAZY)
+    @JoinColumn(name="chat_id")
+    private Chat chat;
+}

--- a/src/main/java/com/memesphere/domain/Collection.java
+++ b/src/main/java/com/memesphere/domain/Collection.java
@@ -1,0 +1,31 @@
+package com.memesphere.domain;
+
+import com.memesphere.domain.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@DynamicUpdate
+@DynamicInsert
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Collection extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name="collect_id")
+    private Long id;
+
+    @ManyToOne(fetch=FetchType.LAZY)
+    @JoinColumn(name="user_id")
+    private User user;
+
+    @ManyToOne(fetch=FetchType.LAZY)
+    @JoinColumn(name="coin_id")
+    private MemeCoin memeCoin;
+}

--- a/src/main/java/com/memesphere/domain/Exchange.java
+++ b/src/main/java/com/memesphere/domain/Exchange.java
@@ -1,0 +1,35 @@
+package com.memesphere.domain;
+
+import com.memesphere.domain.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@DynamicUpdate
+@DynamicInsert
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Exchange extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name="exchange_id")
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column
+    private String image;
+
+    @Column(nullable = false)
+    private String url;
+}

--- a/src/main/java/com/memesphere/domain/FGIndex.java
+++ b/src/main/java/com/memesphere/domain/FGIndex.java
@@ -1,0 +1,34 @@
+package com.memesphere.domain;
+
+import com.memesphere.domain.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
+
+import java.time.LocalDate;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@DynamicUpdate
+@DynamicInsert
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FGIndex extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name="index_id")
+    private Long id;
+
+    @Column(nullable = false)
+    private LocalDate date;
+
+    @Column(nullable = false)
+    private Integer score;
+
+    @Column(nullable = false)
+    private String status;
+}

--- a/src/main/java/com/memesphere/domain/MemeCoin.java
+++ b/src/main/java/com/memesphere/domain/MemeCoin.java
@@ -1,0 +1,65 @@
+package com.memesphere.domain;
+
+import com.memesphere.domain.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
+
+import java.util.ArrayList;
+import java.util.List;
+
+
+@Entity
+@Getter
+@Setter
+@Builder
+@DynamicUpdate
+@DynamicInsert
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemeCoin extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name="coin_id")
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false, unique = true)
+    private String symbol;
+
+    @Column
+    private String image;
+
+    @Column
+    private String description;
+
+    @Column
+    private Integer total_transaction;
+
+    @ElementCollection
+    @CollectionTable(name = "CoinKeywords", joinColumns = @JoinColumn(name = "coin_id"))
+    @Column(name = "keyword")
+    private List<String> keywords = new ArrayList<>();
+
+    @OneToMany(mappedBy = "memeCoin", cascade = CascadeType.ALL)
+    private List<Collection> collectionList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "memeCoin", cascade = CascadeType.ALL)
+    private List<Notification> notificationList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "memeCoin", cascade = CascadeType.ALL)
+    private List<Chat> chatList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "memeCoin", cascade = CascadeType.ALL)
+    private List<Trading> tradingList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "memeCoin", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<MemeExchange> memeExchangeList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "memeCoin", cascade = CascadeType.ALL)
+    private List<ChartData> chartDataList = new ArrayList<>();
+}

--- a/src/main/java/com/memesphere/domain/MemeExchange.java
+++ b/src/main/java/com/memesphere/domain/MemeExchange.java
@@ -1,0 +1,31 @@
+package com.memesphere.domain;
+
+import com.fasterxml.jackson.databind.ser.Serializers;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@DynamicUpdate
+@DynamicInsert
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemeExchange extends Serializers.Base {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name="memeExchange_id")
+    private Long id;
+
+    @ManyToOne(fetch=FetchType.LAZY)
+    @JoinColumn(name="coin_id")
+    private MemeCoin memeCoin;
+
+    @ManyToOne(fetch=FetchType.LAZY)
+    @JoinColumn(name="exchange_id")
+    private Exchange exchange;
+}

--- a/src/main/java/com/memesphere/domain/News.java
+++ b/src/main/java/com/memesphere/domain/News.java
@@ -1,0 +1,38 @@
+package com.memesphere.domain;
+
+import com.memesphere.domain.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@DynamicUpdate
+@DynamicInsert
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class News extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name="news_id")
+    private Long id;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(nullable = false)
+    private String media;
+
+    @Column(nullable = false)
+    private String url;
+
+    @Column
+    private LocalDateTime upload_date;
+}

--- a/src/main/java/com/memesphere/domain/Notification.java
+++ b/src/main/java/com/memesphere/domain/Notification.java
@@ -1,0 +1,43 @@
+package com.memesphere.domain;
+
+import com.memesphere.domain.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@DynamicUpdate
+@DynamicInsert
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Notification extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name="notice_id")
+    private Long id;
+
+    @Column(nullable = false)
+    private Integer volatility;
+
+    @Column(nullable = false)
+    private Integer st_time;
+
+    @Column(nullable = false)
+    private Boolean is_rising;
+
+    @Column(nullable = false)
+    private Boolean is_on;
+
+    @ManyToOne(fetch=FetchType.LAZY)
+    @JoinColumn(name="user_id")
+    private User user;
+
+    @ManyToOne(fetch=FetchType.LAZY)
+    @JoinColumn(name="coin_id")
+    private MemeCoin memeCoin;
+}

--- a/src/main/java/com/memesphere/domain/Trading.java
+++ b/src/main/java/com/memesphere/domain/Trading.java
@@ -1,0 +1,58 @@
+package com.memesphere.domain;
+
+import com.memesphere.domain.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@DynamicUpdate
+@DynamicInsert
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Trading extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name="trading_id")
+    private Long id;
+
+    @Column
+    private LocalDateTime trade_time;
+
+    @Column
+    private Integer volume;
+
+    @Column
+    private BigDecimal price;
+
+    @Column
+    private BigDecimal open_price;
+
+    @Column
+    private BigDecimal close_price;
+
+    @Column
+    private BigDecimal low_price;
+
+    @Column
+    private BigDecimal high_price;
+
+    @Column
+    private BigDecimal change;
+
+    @ManyToOne(fetch=FetchType.LAZY)
+    @JoinColumn(name="user_id")
+    private User user;
+
+    @ManyToOne(fetch=FetchType.LAZY)
+    @JoinColumn(name="coin_id")
+    private MemeCoin memeCoin;
+}

--- a/src/main/java/com/memesphere/domain/User.java
+++ b/src/main/java/com/memesphere/domain/User.java
@@ -1,0 +1,61 @@
+package com.memesphere.domain;
+
+import com.memesphere.domain.common.BaseEntity;
+import com.memesphere.domain.enums.SocialType;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@DynamicUpdate
+@DynamicInsert
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class User extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name="user_id")
+    private long id;
+
+    @Column(nullable = false, unique = true)
+    private String nickname;
+
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private SocialType socialType;
+
+    @Column
+    private String wallet;
+
+    @Column
+    private String image;
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
+    private List<Collection> collectionList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
+    private List<Notification> notificationList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
+    private List<Chat> chatList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
+    private List<ChatLike> chatLikeList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
+    private List<Trading> tradingList = new ArrayList<>();
+}

--- a/src/main/java/com/memesphere/domain/common/BaseEntity.java
+++ b/src/main/java/com/memesphere/domain/common/BaseEntity.java
@@ -1,0 +1,24 @@
+package com.memesphere.domain.common;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+@Setter
+public abstract class BaseEntity {
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/memesphere/domain/enums/SocialType.java
+++ b/src/main/java/com/memesphere/domain/enums/SocialType.java
@@ -1,0 +1,5 @@
+package com.memesphere.domain.enums;
+
+public enum SocialType {
+    NONE, KAKAO, GOOGLE
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #1 개발 환경 세팅

## 📝작업 내용

> 기본 엔티티 생성
![image](https://github.com/user-attachments/assets/37c79654-b730-49f3-8e8c-f615580c99a7)


## 💬리뷰 요구사항(선택)
> 베이스 엔티티
- 일단 createdAt, updatedAt 만 정의

> 유저
- 소셜로그인 enum 타입으로 변경 (NONE, KAKAO, GOOGLE)
- 지갑정보 일단 string으로

> 밈코인
- 키워드 엔티티 생성 없이 리스트 처리
- @ElementCollection + @CollectionTable로 인해 **CoinKeywords 테이블이 생성**되지만 **엔티티는 생성 X**. 
   (JPA가 내부적으로 리스트 데이터를 다루기 위해 생성되었을 뿐)

> 콜렉션
- 이름 길이가 긴 것 같아서.... 엔티티명 변경(FavoriteCoin,관심코인 -> Collectoin)

> 공포탐욕지수
- 이름 길이가 긴 것 같아서.... 엔티티명 변경(FearGreedIndex ->FGIndex)

> 그 외
- 필요한 엔티티나 필드명, 필드 설정 있으면 개발하면서 추가/삭제 해주세요!
- 제 로컬 db는 memesphere로 해둬서 애플리케이션 실행 시, 본인의 db로 바꿔주세요!
![image](https://github.com/user-attachments/assets/3c9d1842-13fc-4ed7-8309-8ee4efcc2bd7)

