### PR TITLE
#4,#5 Feat: 대시보드 상단 관련 controller 구현

### DIFF
--- a/src/main/java/com/memesphere/controller/DashboardController.java
+++ b/src/main/java/com/memesphere/controller/DashboardController.java
@@ -1,0 +1,66 @@
+package com.memesphere.controller;
+
+import com.memesphere.apipayload.ApiResponse;
+import com.memesphere.dto.DashboardDTO;
+import com.memesphere.service.dashboard.DashboardService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name="대시보드", description = "대시보드 관련  API")
+@RestController
+@RequestMapping("/dashboard")
+@RequiredArgsConstructor
+public class DashboardController {
+
+    private final DashboardService dashboardService;
+
+    @GetMapping("/trend")
+    @Operation(summary = "트렌드 조회 API",
+            description = """
+                    밈스피어에 등록된 밈코인의 총 거래량 및 총 개수, \n
+                    그리고 24시간 내 거래량이 가장 많은 밈코인을 5위까지 보여줍니다. \n
+                    
+                    **요청 형식**: ```없음```
+                    
+                    **응답 형식**:
+                    ```
+                    - "totalVolume": 등록된 밈코인의 총 거래량
+                    - "totalCoin": 등록된 밈코인의 총 개수
+                    - "trendList": 등록된 밈코인의 트렌드 순위 리스트(5위 까지)
+                    - "coinId": 밈코인 아이디
+                    - "image": 밈코인 이미지
+                    - "name": 밈코인 이름
+                    - "symbol": 밈코인 심볼
+                    - "price": 밈코인 현재 가격
+                    - "direction": 밈코인 상승(up)/하락(down) 방향
+                    - "priceChange": 변화량
+                    - "percentChange": 변화 퍼센트
+                    ```""")
+    public ApiResponse<DashboardDTO.TrendResponse> getTrendList() {
+        return ApiResponse.onSuccess(dashboardService.findTrendList());
+    }
+
+    @GetMapping("/related-search")
+    @Operation(summary = "연관 검색어 조회 API",
+            description = """
+                    24시간 기준 밈코인과 관련된 연관 검색어 2개를 수치와 함께 보여줍니다. \n
+                    
+                    **요청 형식**: ```없음```
+                    
+                    **응답 형식**:
+                    ```
+                    - "label1": 첫 번째 연관 검색어의 이름,
+                    - "searchVolumeList1": 첫 번째 연관 검색어의 시간에 따른 검색량 수 리스트
+                    - "label2": 두 번째 연관 검색어의 이름
+                    - "searchVolumeList2": 두 번째 연관 검색어의 시간에 따른 검색량 수 리스트
+                    - "time": 시간
+                    - "volume": 검색량
+                    ```""")
+    public ApiResponse<DashboardDTO.RelatedSearchResponse> getRelatedSearch() {
+        return ApiResponse.onSuccess(dashboardService.findRelatedSearch());
+    }
+}

--- a/src/main/java/com/memesphere/dto/DashboardDTO.java
+++ b/src/main/java/com/memesphere/dto/DashboardDTO.java
@@ -1,0 +1,49 @@
+package com.memesphere.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class DashboardDTO {
+
+    @Builder
+    @Getter
+    public static class Trend {
+        private Long coinId;
+        private String image;
+        private String name;
+        private String symbol;
+        private Integer price;
+        private String direction;
+        private Integer priceChange;
+        private Float percentChange;
+    }
+
+    @Builder
+    @Getter
+    public static class TrendResponse {
+        private Integer totalVolume; // 등록된 밈코인의 총 거래량
+        private Integer totalCoin;   // 등록된 밈코인의 총 개수
+        private List<Trend> trendList; // 5위까지의 밈코인 트렌드
+    }
+
+    @Builder
+    @Getter
+    public static class SearchVolume {
+        private LocalDateTime time;
+        private Integer volume; // 검색량
+    }
+
+    @Builder
+    @Getter
+    public static class RelatedSearchResponse {
+        // 시간 당 검색 수이라고 하면 24개*2 = 48개
+        private String label1;
+        private List<SearchVolume> searchVolumeList1;
+
+        private String label2;
+        private List<SearchVolume> searchVolumeList2;
+    }
+}

--- a/src/main/java/com/memesphere/service/dashboard/DashboardService.java
+++ b/src/main/java/com/memesphere/service/dashboard/DashboardService.java
@@ -1,0 +1,8 @@
+package com.memesphere.service.dashboard;
+
+import com.memesphere.dto.DashboardDTO;
+
+public interface DashboardService {
+    DashboardDTO.TrendResponse findTrendList();
+    DashboardDTO.RelatedSearchResponse findRelatedSearch();
+}

--- a/src/main/java/com/memesphere/service/dashboard/DashboardServiceImpl.java
+++ b/src/main/java/com/memesphere/service/dashboard/DashboardServiceImpl.java
@@ -1,0 +1,19 @@
+package com.memesphere.service.dashboard;
+
+import com.memesphere.dto.DashboardDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class DashboardServiceImpl implements DashboardService{
+    @Override
+    public DashboardDTO.TrendResponse findTrendList() {
+        return null;
+    }
+
+    @Override
+    public DashboardDTO.RelatedSearchResponse findRelatedSearch() {
+        return null;
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #4 #5 

## 📝작업 내용

>  ![image](https://github.com/user-attachments/assets/9ce26636-091c-4a8d-b2a4-7df3be0041d9)
대시보드 상단을 두 부분으로 분리하여, 각 api에 대한 controller를 구현
1. 트렌드 조회 API (/dashboard/trend)
2. 연관 검색어 조회 API (/dashboard/related-search)

### 스크린샷
![image](https://github.com/user-attachments/assets/a7597f5d-a836-4940-afe1-c4284bf4e889)
![image](https://github.com/user-attachments/assets/31c23ce4-efc2-419f-85ff-4ff99b666b58)

![image](https://github.com/user-attachments/assets/577e100f-0277-41c8-b153-7797f275a0e4)
![image](https://github.com/user-attachments/assets/1cfcbbad-3184-40d6-a20c-6a9c779f61ad)



## 💬리뷰 요구사항(선택)

> 연관 검색어 조회 api는 외부 api 연결에 따라 다시 응답 형식을 수정해야 할 것 같습니다!
