### PR TITLE
#6 Feat: 스프링 시큐리티 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,10 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+//  security
+	testImplementation 'org.springframework.security:spring-security-test'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/memesphere/config/SecurityConfig.java
+++ b/src/main/java/com/memesphere/config/SecurityConfig.java
@@ -1,0 +1,56 @@
+package com.memesphere.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.CsrfConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
+
+@EnableWebSecurity
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+                .csrf(CsrfConfigurer::disable)
+                .formLogin((auth) -> auth.disable())
+                .sessionManagement(configurer -> configurer.sessionCreationPolicy(
+                        SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests((requests) -> requests
+                        .anyRequest().permitAll() // 일단 인증 없이 모든 요청 허용
+                );
+
+        return http.build();
+    }
+
+    protected CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowedOriginPatterns(List.of("*"));
+        configuration.setExposedHeaders(List.of("*"));
+        configuration.setAllowedHeaders(List.of("*")); //모든 HTTP 헤더를 허용
+        configuration.setAllowedMethods(List.of("*")); //모든 HTTP 메소드를 허용
+        configuration.setAllowCredentials(true); //인증 정보와 관련된 요청을 허용
+        configuration.setMaxAge(3600L);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+
+        return source;
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #6 

## 📝작업 내용

> 1. Spring Security 의존성 추가
> 2. Spring Security를 설정하기 위해서 `SecurityConfig` 클래스 생성
  > - 일단 현재는 모든 경로 요청을 허용하는 설정으로 해놓았습니다. 다른 분들 스웨거 보실 것 같아서 스웨거 url도 아직 추가하지 않았습니다. 추후 로그인 기능 개발하면서 `requestMatchers`에 관련 URL을 추가해둘게요!

## 💬리뷰 요구사항

> 이제 jwt 토큰과 소셜 로그인 구현할 때 폴더 구조를 아래와 같이 할까요?
>
>📦src
┣ 📂main/java/com/memesphere
┃ ┣ 📂apipayload
┃ ┣ 📂config
┃ ┣ 📂controller
┃ ┣ 📂converter
┃ ┣ 📂domain
┃ ┣ 📂dto
┃ ┣ 📂service
┃ ┣ 📂jwt
┃ ┗ 📂oauth
┗ ┗ 📜MemesphereApplication

