### PR TITLE
#11 Feat: 알림 관련 controller 구현

### DIFF
--- a/src/main/java/com/memesphere/controller/CoinNotificationController.java
+++ b/src/main/java/com/memesphere/controller/CoinNotificationController.java
@@ -1,0 +1,105 @@
+package com.memesphere.controller;
+
+
+import com.memesphere.apipayload.ApiResponse;
+import com.memesphere.dto.NotificationDTO;
+import com.memesphere.service.coinNotification.CoinNotificationService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name="알림", description = "알림 관련 API")
+@RestController
+@RequestMapping("/notifications")
+@RequiredArgsConstructor
+public class CoinNotificationController {
+
+    final private CoinNotificationService coinNotificationService;
+
+    @GetMapping
+    @Operation(summary = "등록한 알림 조회 API",
+            description = """
+                    사용자가 등록해 놓은 알림 리스트를 보여줍니다. \n
+                    
+                    **요청 형식**: ```없음```
+                    
+                    **응답 형식**:
+                    ```
+                    - "notificationList": 사용자가 등록한 알림 리스트
+                    - "notificationId": 알림 아이디
+                    - "name": 밈코인 이름
+                    - "symbol": 밈코인 심볼
+                    - "volatility": 변동성
+                    - "st_time": 기준 시간
+                    - "is_rising": 상승(true) 또는 하락(false)
+                    - "is_on": 알림 on(true) 또는 off(false)
+                    ```""")
+    public ApiResponse<NotificationDTO.NotificationListResponse> getNotificationList() {
+        return ApiResponse.onSuccess(coinNotificationService.findNotificationList());
+    }
+
+    @PostMapping
+    @Operation(summary = "알림 등록 API",
+            description = """
+                    사용자가 직접 필드를 입력하여 알림을 등록합니다. \n
+                    
+                    **요청 형식**:
+                    ```
+                    - "name": 밈코인 이름(둘 중 하나만 작성)
+                    - "symbol": 밈코인 심볼(둘 중 하나만 작성)
+                    - "volatility": 변동성
+                    - "st_time": 기준 시간
+                    - "is_rising": 상승(true) 또는 하락(false)
+                    ```
+                    
+                    **응답 형식**:
+                    ```
+                    - "notificationId": 새로 등록된 알림의 밈코인 아이디
+                    - "name": 새로 등록된 알림의 밈코인 아이디
+                    - "symbol": 새로 등록된 알림의 밈코인 아이디
+                    - "volatility": 변동성
+                    - "st_time": 기준 시간
+                    - "is_rising": 상승(true) 또는 하락(false)
+                    - "is_on": 알림 on(true) 또는 off(false)
+                    ```""")
+    public ApiResponse<NotificationDTO.NoticeForm> postNotification(@RequestBody NotificationDTO.NotificationRequest request) {
+        return ApiResponse.onSuccess(coinNotificationService.addNotification(request));
+    }
+
+    @PatchMapping("/{notification-id}")
+    @Operation(summary = "등록한 알림 상태 수정 API",
+            description = """
+                    사용자가 등록한 알림 id를 입력하면 해당 알림의 상태(is_on)를 변경합니다. \n
+                    
+                    **요청 형식**:
+                    ```
+                    - "notification-id": 알림 아이디
+                    ```
+                    
+                    **응답 형식**:
+                    ```
+                    알림 등록 API 응답 형식과 동일
+                    ```""")
+    public ApiResponse<NotificationDTO.NoticeForm> updateNotificationStatus(@PathVariable("notification-id") Long id) {
+        return ApiResponse.onSuccess(coinNotificationService.modifyNotification(id));
+    }
+
+    @DeleteMapping("/{notification-id}")
+    @Operation(summary = "등록한 알림 삭제 API",
+            description = """
+                    사용자가 등록한 알림 id를 입력하면 해당 알림을 삭제합니다. \n
+                    
+                    **요청 형식**:
+                    ```
+                    - "notification-id": 알림 아이디
+                    ```
+                    
+                    **응답 형식**:
+                    ```
+                    등록한 알림 조회 API 응답 형식과 동일
+                    ```""")
+    public ApiResponse<NotificationDTO.NotificationListResponse> deleteNotification(@PathVariable("notification-id") Long id) {
+        return ApiResponse.onSuccess(coinNotificationService.removeNotification(id));
+    }
+}

--- a/src/main/java/com/memesphere/controller/PushNotificationController.java
+++ b/src/main/java/com/memesphere/controller/PushNotificationController.java
@@ -1,0 +1,39 @@
+package com.memesphere.controller;
+
+import com.memesphere.apipayload.ApiResponse;
+import com.memesphere.dto.NotificationDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name="푸시 알림", description = "푸시 알림 관련 API")
+@RestController
+@RequestMapping("/push-notifications")
+@RequiredArgsConstructor
+public class PushNotificationController {
+    @GetMapping
+    @Operation(summary = "푸시 알림 조회 API",
+            description = """
+                    푸시된 알림 리스트를 보여줍니다. \n
+                    푸시 알림을 db에 저장할 필요가 있을까요? \n
+                    읽음 여부를 확인해야 한다면 푸시 알림 테이블을 만드는게 맞을까요?  \n
+                    푸시 알림 기능이 어떻게 작동되는지 몰라서 컨트롤러만 두었습니다.  \n
+                    응답 형식은 일단 무시해주세요.""")
+    public ApiResponse<NotificationDTO.NotificationListResponse> getPushList() {
+        return ApiResponse.onSuccess(null);
+    }
+
+    @DeleteMapping("/{notification-id}")
+    @Operation(summary = "푸시 알림 삭제? 확인? API",
+            description = """
+                    푸시된 알림 리스트를 삭제? 확인?합니다. \n
+                    이 기능은 푸시 알림 기능을 더 정의한 후에 수정해야 할 듯 보입니다. 
+                    """)
+    public ApiResponse<NotificationDTO.NotificationListResponse> deletePushNotification() {
+        return ApiResponse.onSuccess(null);
+    }
+}

--- a/src/main/java/com/memesphere/dto/NotificationDTO.java
+++ b/src/main/java/com/memesphere/dto/NotificationDTO.java
@@ -1,0 +1,39 @@
+package com.memesphere.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+public class NotificationDTO {
+
+    @Getter
+    @Builder
+    public static class NotificationRequest {
+        private String name;
+        private String symbol;
+        private Integer volatility;
+        private Integer st_time;
+        private Boolean is_rising;
+    }
+
+
+    @Builder
+    @Getter
+    public static class NoticeForm {
+        private Long notificationId;
+        private String name;
+        private String symbol;
+        private Integer volatility;
+        private Integer st_time;
+        private Boolean is_rising;
+        private Boolean is_on;
+    }
+
+    @Builder
+    @Getter
+    public static class NotificationListResponse {
+        private List<NoticeForm> notificationList;
+    }
+}

--- a/src/main/java/com/memesphere/service/coinNotification/CoinNotificationService.java
+++ b/src/main/java/com/memesphere/service/coinNotification/CoinNotificationService.java
@@ -1,0 +1,10 @@
+package com.memesphere.service.coinNotification;
+
+import com.memesphere.dto.NotificationDTO;
+
+public interface CoinNotificationService {
+    NotificationDTO.NotificationListResponse findNotificationList();
+    NotificationDTO.NoticeForm addNotification(NotificationDTO.NotificationRequest notificationRequest);
+    NotificationDTO.NoticeForm modifyNotification(Long notificationId);
+    NotificationDTO.NotificationListResponse removeNotification(Long notificationId);
+}

--- a/src/main/java/com/memesphere/service/coinNotification/CoinNotificationServiceImpl.java
+++ b/src/main/java/com/memesphere/service/coinNotification/CoinNotificationServiceImpl.java
@@ -1,0 +1,30 @@
+package com.memesphere.service.coinNotification;
+
+import com.memesphere.dto.NotificationDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CoinNotificationServiceImpl implements CoinNotificationService {
+
+    @Override
+    public NotificationDTO.NotificationListResponse findNotificationList() {
+        return null;
+    }
+
+    @Override
+    public NotificationDTO.NoticeForm addNotification(NotificationDTO.NotificationRequest request) {
+        return null;
+    }
+
+    @Override
+    public NotificationDTO.NoticeForm modifyNotification(Long notificationId) {
+        return null;
+    }
+
+    @Override
+    public NotificationDTO.NotificationListResponse removeNotification(Long notificationId) {
+        return null;
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #11

## 📝작업 내용

> 알림 관련 API 컨트롤러 구현
![image](https://github.com/user-attachments/assets/af18a058-b6a5-4727-a02b-b3e59421fc4e)
1. 알림 등록하기 (POST /notifications)
2. 사용자가 등록한 알림 조회 (GET/notifications)
3. 알림 상태 변경 (PATCH/notifications/id)
4. 알림 삭제하기 (DELETE /notifications/id)
5. 푸시 알림 조회 (GET/push-notifications )
6. 푸시 알림 삭제? 확인? (DELETE? PATCH? /push-notifications ) <- 예상

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/e9e4a61b-cf20-47c9-8167-0b317bf0f0dc)
알림을 코인알림/푸시알림으로 나누어 컨트롤러 역시 분리

> ![image](https://github.com/user-attachments/assets/4bf968ec-5cdb-4f0d-886b-2921a0c42bd0)
![image](https://github.com/user-attachments/assets/483106ab-e579-4425-9625-4aed9cbebf64)


> ![image](https://github.com/user-attachments/assets/3b2a73bd-9481-4fb0-bb6b-54b8ed48f5ca)
![image](https://github.com/user-attachments/assets/5c4374bb-eed5-43e4-97ca-bffdb3d4277e)
![image](https://github.com/user-attachments/assets/6c793974-9b4d-466b-9245-809b39693db5)


> ![image](https://github.com/user-attachments/assets/dfc36ced-1e59-46f7-b972-065274c768b4)
![image](https://github.com/user-attachments/assets/482a21b9-79d8-41c9-8fd8-67fbdad3e09c)
![image](https://github.com/user-attachments/assets/0b1dccd9-c356-48cd-a927-a91f3d90268b)


> ![image](https://github.com/user-attachments/assets/51da1bba-02ee-4b5e-a9d4-729e45157d5b)
![image](https://github.com/user-attachments/assets/54251169-20cf-4426-8209-1a976861ba4d)


## 💬리뷰 요구사항(선택)

> 푸시 알림 api 관련해서 궁금한 부분이 많고 푸시 알림 기능이 어떻게 작동되는지 모르기에
                   
                    - 푸시 알림을 db에 저장할 필요가 있을까요? (-> 엔티티 및 테이블 필요?)
                    - 각 푸시 알림에 대한 읽음 여부를 확인 기능이 있다면 한다면 푸시 알림 테이블을 만드는 게 맞을까요?  
                    - 그래서 각 푸시 알림에 대한 읽음 여부를 확인 기능을 넣을 예정?
                    
 일단 컨트롤러 틀만 두었습니다. (5, 6번 API 응답 형식은 일단 무시해주세요.)

또 컨트롤러, DTO, 서비스 클래스명, 메소드명 노션에 적힌 규칙대로 나름 작성했으나, 
추후에 팀원들 코드 참고하여 다시 이름 및 패키지 구조 수정하겠습니다