### PR TITLE
#30 Fix: market cap 대체 반영

### DIFF
--- a/src/main/java/com/memesphere/controller/SearchRestController.java
+++ b/src/main/java/com/memesphere/controller/SearchRestController.java
@@ -30,7 +30,7 @@ public class SearchRestController {
     public ApiResponse<SearchPageResponse> getSearchPage(
             @RequestParam(name = "searchWord") String searchWord, // 검색어
             @RequestParam(name = "viewType", defaultValue = "GRID") ViewType viewType, // 뷰 타입 (grid 또는 list)
-            @RequestParam(name = "sortType", defaultValue = "MKT_CAP") SortType sortType, // 정렬 기준 (MKTCap, 24h Volume, Price)
+            @RequestParam(name = "sortType", defaultValue = "PRICE_CHANGE") SortType sortType, // 정렬 기준 (MKTCap, 24h Volume, Price)
             @CheckPage @RequestParam(name = "page") Integer page // 페이지 번호
 //            @AuthenticationPrincipal UserDetails user // 현재 로그인한 유저
     ) {

--- a/src/main/java/com/memesphere/converter/CollectionConverter.java
+++ b/src/main/java/com/memesphere/converter/CollectionConverter.java
@@ -35,7 +35,8 @@ public class CollectionConverter {
                 .currentPrice(memeCoin.getChartData().getPrice())
                 .highPrice(memeCoin.getChartData().getHigh_price())
                 .lowPrice(memeCoin.getChartData().getLow_price())
-                .variation(memeCoin.getChartData().getPrice_change())
+                .priceChange(memeCoin.getChartData().getPriceChange())
+                .priceChangeRate(memeCoin.getChartData().getPriceChangeRate())
                 .build();
     }
 }

--- a/src/main/java/com/memesphere/converter/DashboardConverter.java
+++ b/src/main/java/com/memesphere/converter/DashboardConverter.java
@@ -38,9 +38,9 @@ public class DashboardConverter {
                 .name(memeCoin.getName())
                 .symbol(memeCoin.getSymbol())
                 .price(data.getPrice().intValue()) // todo: 외부 api 응답 형식 보고 엔티티 자료형 변경
-                .priceChange(data.getPrice_change().intValue())
-                .changeAbsolute(Math.abs(data.getPrice_change().intValue()))
-                .changeDirection(data.getPrice_change().intValue() > 0? "up" : "down")
+                .priceChange(data.getPriceChange().intValue())
+                .changeAbsolute(Math.abs(data.getPriceChange().intValue()))
+                .changeDirection(data.getPriceChange().intValue() > 0? "up" : "down")
                 .changeRate(null) // todo: string할건지 float형 할건지 결정
                 .build();
     }

--- a/src/main/java/com/memesphere/converter/SearchConverter.java
+++ b/src/main/java/com/memesphere/converter/SearchConverter.java
@@ -44,7 +44,8 @@ public class SearchConverter {
                 .currentPrice(memeCoin.getChartData().getPrice())
                 .highPrice(memeCoin.getChartData().getHigh_price())
                 .lowPrice(memeCoin.getChartData().getLow_price())
-                .variation(memeCoin.getChartData().getPrice_change())
+                .priceChange(memeCoin.getChartData().getPriceChange())
+                .priceChangeRate(memeCoin.getChartData().getPriceChangeRate())
                 .isCollected(isCollected)
                 .build();
     }
@@ -54,7 +55,8 @@ public class SearchConverter {
                 .name(memeCoin.getName())
                 .symbol(memeCoin.getSymbol())
                 .currentPrice(memeCoin.getChartData().getPrice())
-                .market_cap(memeCoin.getChartData().getMarketCap())
+                .priceChange(memeCoin.getChartData().getPriceChangeRate())
+                .weightedAveragePrice(memeCoin.getChartData().getWeighted_average_price())
                 .volume(memeCoin.getChartData().getVolume())
                 .isCollected(isCollected)
                 .build();

--- a/src/main/java/com/memesphere/domain/ChartData.java
+++ b/src/main/java/com/memesphere/domain/ChartData.java
@@ -29,10 +29,16 @@ public class ChartData extends BaseEntity {
     private BigDecimal price;
 
     @Column
-    private BigDecimal price_change;
+    private BigDecimal priceChange;
 
     @Column
-    private BigDecimal marketCap;
+    private BigDecimal priceChangeRate;
+
+//    @Column
+//    private BigDecimal marketCap;
+
+    @Column
+    private BigDecimal weighted_average_price;
 
     @Column
     private Integer volume;

--- a/src/main/java/com/memesphere/domain/enums/SortType.java
+++ b/src/main/java/com/memesphere/domain/enums/SortType.java
@@ -1,5 +1,5 @@
 package com.memesphere.domain.enums;
 
 public enum SortType {
-    MKT_CAP, VOLUME_24H, PRICE
+    PRICE_CHANGE, VOLUME_24H, PRICE
 }

--- a/src/main/java/com/memesphere/dto/response/CollectionPreviewResponse.java
+++ b/src/main/java/com/memesphere/dto/response/CollectionPreviewResponse.java
@@ -26,5 +26,7 @@ public class CollectionPreviewResponse {
     @Schema(description = "차트 데이터의 low_price", example = "1500")
     BigDecimal lowPrice;
     @Schema(description = "차트 데이터의 price_change", example = "500")
-    BigDecimal variation;
+    BigDecimal priceChange;
+    @Schema(description = "차트 데이터의 price_change_rate", example = "2.4")
+    BigDecimal priceChangeRate;
 }

--- a/src/main/java/com/memesphere/dto/response/SearchGridPreviewResponse.java
+++ b/src/main/java/com/memesphere/dto/response/SearchGridPreviewResponse.java
@@ -26,7 +26,9 @@ public class SearchGridPreviewResponse {
     @Schema(description = "차트 데이터의 low_price", example = "1500")
     BigDecimal lowPrice;
     @Schema(description = "차트 데이터의 price_change", example = "500")
-    BigDecimal variation;
+    BigDecimal priceChange;
+    @Schema(description = "차트 데이터의 price_change_rate", example = "+2.4%")
+    BigDecimal priceChangeRate;
     @Schema(description = "collection에 해당 밈코인 유무", example = "true / false")
     Boolean isCollected;
 }

--- a/src/main/java/com/memesphere/dto/response/SearchListPreviewResponse.java
+++ b/src/main/java/com/memesphere/dto/response/SearchListPreviewResponse.java
@@ -20,12 +20,14 @@ public class SearchListPreviewResponse {
     // market cap = currentPrice x volume
     @Schema(description = "차트 데이터의 price", example = "2000")
     BigDecimal currentPrice;
-    @Schema(description = "차트 데이터의 marketCap", example = "10000")
-    BigDecimal market_cap;
+    @Schema(description = "차트 데이터의 weighted average price", example = "10000")
+    BigDecimal weightedAveragePrice;
     @Schema(description = "차트 데이터의 volume", example = "5")
     Integer volume;
     @Schema(description = "차트 데이터의 price_change", example = "500")
-    BigDecimal variation;
+    BigDecimal priceChange;
+    @Schema(description = "차트 데이터의 price_change_rate", example = "+2.4%")
+    BigDecimal priceChangeRate;
     @Schema(description = "collection에 해당 밈코인 유무", example = "true / false")
     Boolean isCollected;
 }

--- a/src/main/java/com/memesphere/service/searchService/SearchQueryServiceImpl.java
+++ b/src/main/java/com/memesphere/service/searchService/SearchQueryServiceImpl.java
@@ -33,7 +33,7 @@ public class SearchQueryServiceImpl implements SearchQueryService {
         };
 
         String sortField = switch (sortType) {
-            case MKT_CAP -> "chartData.marketCap";
+            case PRICE_CHANGE -> "chartData.priceChange";
             case VOLUME_24H -> "chartData.volume";
             case PRICE -> "chartData.price";
             default -> throw new GeneralException(ErrorStatus.UNSUPPORTED_SORT_TYPE);

--- a/src/main/java/com/memesphere/service/user/KakaoServiceImpl.java
+++ b/src/main/java/com/memesphere/service/user/KakaoServiceImpl.java
@@ -29,13 +29,13 @@ public class KakaoServiceImpl implements KakaoService {
     private final UserServiceImpl userServiceImpl;
     private final UserRepository userRepository;
 
-    @Value("${security.oauth2.client.registration.kakao.client-id}")
+    @Value("${spring.security.oauth2.client.registration.kakao.client-id}")
     private String clientId;
 
-    @Value("${security.oauth2.client.provider.kakao.token-uri}")
+    @Value("${spring.security.oauth2.client.provider.kakao.token-uri}")
     private String tokenUri;
 
-    @Value("${security.oauth2.client.provider.kakao.user-info-uri}")
+    @Value("${spring.security.oauth2.client.provider.kakao.user-info-uri}")
     private String userInfoUri;
 
     public KakaoTokenResponse getAccessTokenFromKakao(String code) {

--- a/src/main/java/com/memesphere/service/user/KakaoServiceImpl.java
+++ b/src/main/java/com/memesphere/service/user/KakaoServiceImpl.java
@@ -29,13 +29,13 @@ public class KakaoServiceImpl implements KakaoService {
     private final UserServiceImpl userServiceImpl;
     private final UserRepository userRepository;
 
-    @Value("${spring.security.oauth2.client.registration.kakao.client-id}")
+    @Value("${security.oauth2.client.registration.kakao.client-id}")
     private String clientId;
 
-    @Value("${spring.security.oauth2.client.provider.kakao.token-uri}")
+    @Value("${security.oauth2.client.provider.kakao.token-uri}")
     private String tokenUri;
 
-    @Value("${spring.security.oauth2.client.provider.kakao.user-info-uri}")
+    @Value("${security.oauth2.client.provider.kakao.user-info-uri}")
     private String userInfoUri;
 
     public KakaoTokenResponse getAccessTokenFromKakao(String code) {


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #30 

## 📝작업 내용

> - Binance API에서 Market Cap 관련 정보를 제공하지 않음
> - 전체 회의를 통해서 검색 결과 리스트 뷰에서는 Market Cap 대체로 Weighted Average Price를, 정렬 기준에서는 Price Change를 사용하기로 결정
> - 해당 사항 반영
> - priceChangeRate 필드 추가 
> - 포스트맨으로 에러나지 않는 것 확인했습니당

## 💬리뷰 요구사항

> priceChange 필드를 정렬 기준에 적용하기 위하여 camel case로 바꿨습니다 (에러가 나는 부분은 모두 수정했습니당)
> priceChangeRate 필드가 필요한 부분에 가져다가 사용하시면 될 것 같아요! 

