### PR TITLE
#38 Feat: 구글 로그인 구현

### DIFF
--- a/src/main/java/com/memesphere/domain/user/controller/TestLoginController.java
+++ b/src/main/java/com/memesphere/domain/user/controller/TestLoginController.java
@@ -7,13 +7,17 @@ import org.springframework.web.bind.annotation.GetMapping;
 @org.springframework.stereotype.Controller
 public class TestLoginController {
 
-    @Value("${testLoginUrl}")
-    private String testLoginUrl;
+    @Value("${testKakaoLoginUrl}")
+    private String testKakaoLoginUrl;
+
+    @Value("${testGoogleLoginUrl}")
+    private String testGoogleLoginUrl;
 
     @GetMapping("/login")
     public String login(Model model) {
 
-        model.addAttribute("testLoginUrl", testLoginUrl);
+        model.addAttribute("testKakaoLoginUrl", testKakaoLoginUrl);
+        model.addAttribute("testGoogleLoginUrl", testGoogleLoginUrl);
         return "login";
     }
 }

--- a/src/main/java/com/memesphere/domain/user/controller/UserController.java
+++ b/src/main/java/com/memesphere/domain/user/controller/UserController.java
@@ -2,9 +2,11 @@ package com.memesphere.domain.user.controller;
 
 import com.memesphere.domain.user.dto.request.SignInRequest;
 import com.memesphere.domain.user.dto.request.SignUpRequest;
+import com.memesphere.domain.user.dto.response.GoogleUserInfoResponse;
 import com.memesphere.domain.user.dto.response.TokenResponse;
 import com.memesphere.domain.user.dto.response.KakaoUserInfoResponse;
 import com.memesphere.domain.user.service.AuthServiceImpl;
+import com.memesphere.domain.user.service.GoogleServiceImpl;
 import com.memesphere.domain.user.service.KakaoServiceImpl;
 import com.memesphere.global.apipayload.ApiResponse;
 import com.memesphere.domain.user.dto.response.LoginResponse;
@@ -23,14 +25,25 @@ import java.io.IOException;
 public class UserController {
 
     private final KakaoServiceImpl kakaoServiceImpl;
+    private final GoogleServiceImpl googleServiceImpl;
     private final AuthServiceImpl authServiceImpl;
 
     @PostMapping("/login/oauth2/kakao")
     @Operation(summary = "카카오 로그인/회원가입 API")
-    public ApiResponse<LoginResponse> callback(@RequestParam("code") String code) throws IOException {
+    public ApiResponse<LoginResponse> kakaoLogin(@RequestParam("code") String code) throws IOException {
         TokenResponse kakaoTokenResponse = kakaoServiceImpl.getAccessTokenFromKakao(code);
         KakaoUserInfoResponse kakaoUserInfoResponse = kakaoServiceImpl.getUserInfo(kakaoTokenResponse.getAccessToken());
         LoginResponse loginResponse = kakaoServiceImpl.handleUserLogin(kakaoUserInfoResponse);
+
+        return ApiResponse.onSuccess(loginResponse);
+    }
+
+    @PostMapping("/login/oauth2/google")
+    @Operation(summary = "구글 로그인/회원가입 API")
+    public ApiResponse<LoginResponse> googleLogin(@RequestParam("code") String code) throws IOException {
+        TokenResponse googleTokenResponse = googleServiceImpl.getAccessTokenFromGoogle(code);
+        GoogleUserInfoResponse googleUserInfoResponse = googleServiceImpl.getUserInfo(googleTokenResponse.getAccessToken());
+        LoginResponse loginResponse = googleServiceImpl.handleUserLogin(googleUserInfoResponse);
 
         return ApiResponse.onSuccess(loginResponse);
     }

--- a/src/main/java/com/memesphere/domain/user/controller/UserController.java
+++ b/src/main/java/com/memesphere/domain/user/controller/UserController.java
@@ -1,5 +1,6 @@
 package com.memesphere.domain.user.controller;
 
+import com.memesphere.domain.user.dto.request.NicknameRequest;
 import com.memesphere.domain.user.dto.request.SignInRequest;
 import com.memesphere.domain.user.dto.request.SignUpRequest;
 import com.memesphere.domain.user.dto.response.GoogleUserInfoResponse;
@@ -10,6 +11,7 @@ import com.memesphere.domain.user.service.GoogleServiceImpl;
 import com.memesphere.domain.user.service.KakaoServiceImpl;
 import com.memesphere.global.apipayload.ApiResponse;
 import com.memesphere.domain.user.dto.response.LoginResponse;
+import com.memesphere.global.apipayload.code.status.ErrorStatus;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -60,5 +62,17 @@ public class UserController {
     public ApiResponse<LoginResponse> login(@Valid @RequestBody SignInRequest signInRequest) {
         LoginResponse loginResponse = authServiceImpl.handleUserLogin(signInRequest);
         return ApiResponse.onSuccess(loginResponse);
+    }
+
+    @PostMapping("/signup/nickname/validate")
+    @Operation(summary = "닉네임 중복 확인 API")
+    public ApiResponse<?> isNicknameValidate(@RequestBody NicknameRequest nicknameRequest) {
+        boolean isDuplicate = authServiceImpl.checkNicknameDuplicate(nicknameRequest.getNickname());
+
+        if (isDuplicate) {
+            return ApiResponse.onSuccess("이미 사용 중인 닉네임입니다.");
+        } else {
+            return ApiResponse.onSuccess("사용 가능한 닉네임입니다.");
+        }
     }
 }

--- a/src/main/java/com/memesphere/domain/user/converter/UserConverter.java
+++ b/src/main/java/com/memesphere/domain/user/converter/UserConverter.java
@@ -1,6 +1,7 @@
 package com.memesphere.domain.user.converter;
 
 import com.memesphere.domain.user.dto.request.SignUpRequest;
+import com.memesphere.domain.user.dto.response.GoogleUserInfoResponse;
 import com.memesphere.domain.user.entity.SocialType;
 import com.memesphere.domain.user.entity.User;
 import com.memesphere.domain.user.dto.response.TokenResponse;
@@ -32,6 +33,31 @@ public class UserConverter {
                 .userRole(UserRole.USER)
                 .accessToken(tokenResponse.getAccessToken())
                 .refreshToken(tokenResponse.getRefreshToken())
+                .build();
+    }
+
+    // 구글 로그인 유저
+    public static User toGoogleUser(GoogleUserInfoResponse googleUserInfoResponse) {
+        return User.builder()
+                .loginId(UUID.randomUUID().getMostSignificantBits() & Long.MAX_VALUE)
+                .nickname(googleUserInfoResponse.getName())
+                .email(googleUserInfoResponse.getEmail())
+                .profileImage(googleUserInfoResponse.getPicture())
+                .socialType(SocialType.GOOGLE)
+                .userRole(UserRole.USER)
+                .build();
+    }
+
+    public static User toUpdatedGoogleUser(GoogleUserInfoResponse googleUserInfoResponse, TokenResponse tokenResponse) {
+        return User.builder()
+                .loginId(UUID.randomUUID().getMostSignificantBits() & Long.MAX_VALUE)
+                .nickname(googleUserInfoResponse.getName())
+                .email(googleUserInfoResponse.getEmail())
+                .profileImage(googleUserInfoResponse.getPicture())
+                .accessToken(tokenResponse.getAccessToken())
+                .refreshToken(tokenResponse.getRefreshToken())
+                .socialType(SocialType.GOOGLE)
+                .userRole(UserRole.USER)
                 .build();
     }
 

--- a/src/main/java/com/memesphere/domain/user/dto/request/NicknameRequest.java
+++ b/src/main/java/com/memesphere/domain/user/dto/request/NicknameRequest.java
@@ -1,0 +1,19 @@
+package com.memesphere.domain.user.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class NicknameRequest {
+
+    @NotEmpty
+    @Schema(description = "닉네임", example = "홍길동")
+    private String nickname;
+}

--- a/src/main/java/com/memesphere/domain/user/dto/response/GoogleUserInfoResponse.java
+++ b/src/main/java/com/memesphere/domain/user/dto/response/GoogleUserInfoResponse.java
@@ -1,0 +1,21 @@
+package com.memesphere.domain.user.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class GoogleUserInfoResponse {
+
+    @Schema(description = "계정 유저 이름", example = "홍길동")
+    private String name;
+
+    @Schema(description = "계정 프로필 이미지", example = "https://lh3.googleusercontent.com/a/ACg8ocL1gRaTq2dfArGVEQC_fcEMdc101SbmOGE2u_-68LosJmIPOg=s96-c")
+    private String picture;
+
+    @Schema(description = "계정 이메일", example = "abc123@gmail.com")
+    private String email;
+}

--- a/src/main/java/com/memesphere/domain/user/entity/User.java
+++ b/src/main/java/com/memesphere/domain/user/entity/User.java
@@ -36,7 +36,6 @@ public class User extends BaseEntity {
     @Column(unique = true)
     private String email;
 
-    @Setter
     private String password;
 
     @Column(length = 8)
@@ -46,14 +45,10 @@ public class User extends BaseEntity {
 
     private String wallet;
 
-    @Setter
     private String accessToken;
 
-    @Setter
     private String refreshToken;
 
-
-    @Setter
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private SocialType socialType;
@@ -76,4 +71,12 @@ public class User extends BaseEntity {
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
     @Builder.Default
     private List<ChatLike> chatLikeList = new ArrayList<>();
+
+    public void saveAccessToken(String accessToken) {
+        this.accessToken = accessToken;
+    }
+
+    public void saveRefreshToken(String refreshToken) {
+        this.refreshToken = refreshToken;
+    }
 }

--- a/src/main/java/com/memesphere/domain/user/entity/User.java
+++ b/src/main/java/com/memesphere/domain/user/entity/User.java
@@ -39,10 +39,10 @@ public class User extends BaseEntity {
     @Setter
     private String password;
 
-    @Setter
-    @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
-    private SocialType socialType;
+    @Column(length = 8)
+    private String birth;
+
+    private String profileImage;
 
     private String wallet;
 
@@ -52,11 +52,14 @@ public class User extends BaseEntity {
     @Setter
     private String refreshToken;
 
+
+    @Setter
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private SocialType socialType;
+
     @Enumerated(EnumType.STRING)
     private UserRole userRole;
-
-    @Column(length = 8)
-    private String birth;
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
     @Builder.Default

--- a/src/main/java/com/memesphere/domain/user/service/AuthServiceImpl.java
+++ b/src/main/java/com/memesphere/domain/user/service/AuthServiceImpl.java
@@ -49,8 +49,8 @@ public class AuthServiceImpl implements AuthService{
             accessToken = tokenProvider.createAccessToken(existingUser.getEmail(), existingUser.getLoginId());
             String refreshToken = tokenProvider.createRefreshToken(existingUser.getEmail());
 
-            existingUser.setAccessToken(accessToken);
-            existingUser.setRefreshToken(refreshToken);
+            existingUser.saveAccessToken(accessToken);
+            existingUser.saveRefreshToken(refreshToken);
             userRepository.save(existingUser);
             return new LoginResponse(accessToken, refreshToken);
         } else {

--- a/src/main/java/com/memesphere/domain/user/service/GoogleService.java
+++ b/src/main/java/com/memesphere/domain/user/service/GoogleService.java
@@ -1,0 +1,12 @@
+package com.memesphere.domain.user.service;
+
+import com.memesphere.domain.user.dto.response.GoogleUserInfoResponse;
+import com.memesphere.domain.user.dto.response.LoginResponse;
+import com.memesphere.domain.user.dto.response.TokenResponse;
+
+public interface GoogleService {
+    TokenResponse getAccessTokenFromGoogle(String code);
+    GoogleUserInfoResponse getUserInfo(String accessToken);
+    void handleUserRegistration(GoogleUserInfoResponse userInfo, TokenResponse kakaoTokenResponse);
+    LoginResponse handleUserLogin(GoogleUserInfoResponse userInfo);
+}

--- a/src/main/java/com/memesphere/domain/user/service/GoogleServiceImpl.java
+++ b/src/main/java/com/memesphere/domain/user/service/GoogleServiceImpl.java
@@ -1,0 +1,131 @@
+package com.memesphere.domain.user.service;
+
+import com.memesphere.domain.user.converter.UserConverter;
+import com.memesphere.domain.user.dto.response.GoogleUserInfoResponse;
+import com.memesphere.domain.user.dto.response.KakaoUserInfoResponse;
+import com.memesphere.domain.user.dto.response.LoginResponse;
+import com.memesphere.domain.user.dto.response.TokenResponse;
+import com.memesphere.domain.user.entity.SocialType;
+import com.memesphere.domain.user.entity.User;
+import com.memesphere.domain.user.repository.UserRepository;
+import com.memesphere.global.apipayload.exception.GeneralException;
+import com.memesphere.global.jwt.TokenProvider;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class GoogleServiceImpl implements GoogleService{
+
+    private final TokenProvider tokenProvider;
+    private final UserServiceImpl userServiceImpl;
+    private final UserRepository userRepository;
+
+    @Value("${security.oauth2.client.registration.google.client-id}")
+    private String clientId;
+
+    @Value("${security.oauth2.client.registration.google.client-secret}")
+    private String clientSecret;
+
+    @Value("${security.oauth2.client.registration.google.redirect-uri}")
+    private String redirectUri;
+
+    @Value("${security.oauth2.client.registration.google.authorization-grant-type}")
+    private String authorizationCode;
+
+    @Value("${security.oauth2.client.provider.google.token-uri}")
+    private String tokenUri;
+
+    @Value("${security.oauth2.client.provider.google.user-info-uri}")
+    private String userInfoUri;
+
+
+    public TokenResponse getAccessTokenFromGoogle(String code) {
+        try {
+            String decodedCode = URLDecoder.decode(code, StandardCharsets.UTF_8);
+
+            RestTemplate restTemplate = new RestTemplate();
+            String uri = UriComponentsBuilder.fromUriString(tokenUri)
+                    .queryParam("grant_type", authorizationCode)
+                    .queryParam("client_id", clientId)
+                    .queryParam("redirect_uri", redirectUri)
+                    .queryParam("code", decodedCode)
+                    .queryParam("client_secret", clientSecret)
+                    .toUriString();
+
+            ResponseEntity<TokenResponse> responseEntity = restTemplate.postForEntity(uri, null, TokenResponse.class);
+            return responseEntity.getBody();
+        } catch (Exception e) {
+            log.error("Error occurred while getting access token from Google: ", e);
+            throw new RuntimeException("Failed to retrieve access token from Google", e);
+        }
+    }
+
+    public GoogleUserInfoResponse getUserInfo(String accessToken) {
+        try {
+            RestTemplate restTemplate = new RestTemplate();
+            HttpHeaders headers = new HttpHeaders();
+            headers.set("Authorization", "Bearer " + accessToken);
+            HttpEntity<String> entity = new HttpEntity<>(headers);
+
+            String uri = UriComponentsBuilder.fromUriString(userInfoUri).toUriString();
+
+            ResponseEntity<GoogleUserInfoResponse> responseEntity = restTemplate.exchange(uri, HttpMethod.GET, entity, GoogleUserInfoResponse.class);
+            return responseEntity.getBody();
+        } catch (Exception e) {
+            log.error("Error occurred while getting user info from Google: ", e);
+            throw new RuntimeException("Failed to retrieve user info from Google", e);
+        }
+    }
+
+    public void handleUserRegistration(GoogleUserInfoResponse googleUserInfoResponse, TokenResponse tokenResponse) {
+        String email = googleUserInfoResponse.getEmail();
+        User existingUser = userRepository.findByEmail(email).orElse(null);
+
+        if (existingUser == null) {
+            User newUser = UserConverter.toGoogleUser(googleUserInfoResponse);
+            userServiceImpl.save(newUser);
+        } else {
+            User updatedUser = UserConverter.toUpdatedGoogleUser(googleUserInfoResponse, tokenResponse);
+            userServiceImpl.save(updatedUser);
+        }
+    }
+
+    public LoginResponse handleUserLogin(GoogleUserInfoResponse googleUserInfoResponse) {
+        User existingUser = userRepository.findByEmail(googleUserInfoResponse.getEmail()).orElse(null);
+        String accessToken;
+
+        if (existingUser != null) {
+
+            accessToken = tokenProvider.createAccessToken(existingUser.getEmail(), existingUser.getLoginId());
+            String refreshToken = tokenProvider.createRefreshToken(existingUser.getEmail());
+
+            existingUser.setAccessToken(accessToken);
+            existingUser.setRefreshToken(refreshToken);
+            userRepository.save(existingUser);
+
+            return new LoginResponse(accessToken, refreshToken);
+        } else {
+            User newUser = UserConverter.toGoogleUser(googleUserInfoResponse);
+            newUser = userRepository.save(newUser);
+
+            accessToken = tokenProvider.createAccessToken(newUser.getEmail(), newUser.getLoginId());
+            String refreshToken = tokenProvider.createRefreshToken(newUser.getEmail());
+
+            newUser.setAccessToken(accessToken);
+            newUser.setRefreshToken(refreshToken);
+            userRepository.save(newUser);
+
+            return new LoginResponse(accessToken, refreshToken);
+        }
+    }
+}

--- a/src/main/java/com/memesphere/domain/user/service/GoogleServiceImpl.java
+++ b/src/main/java/com/memesphere/domain/user/service/GoogleServiceImpl.java
@@ -109,8 +109,8 @@ public class GoogleServiceImpl implements GoogleService{
             accessToken = tokenProvider.createAccessToken(existingUser.getEmail(), existingUser.getLoginId());
             String refreshToken = tokenProvider.createRefreshToken(existingUser.getEmail());
 
-            existingUser.setAccessToken(accessToken);
-            existingUser.setRefreshToken(refreshToken);
+            existingUser.saveAccessToken(accessToken);
+            existingUser.saveRefreshToken(refreshToken);
             userRepository.save(existingUser);
 
             return new LoginResponse(accessToken, refreshToken);
@@ -121,8 +121,8 @@ public class GoogleServiceImpl implements GoogleService{
             accessToken = tokenProvider.createAccessToken(newUser.getEmail(), newUser.getLoginId());
             String refreshToken = tokenProvider.createRefreshToken(newUser.getEmail());
 
-            newUser.setAccessToken(accessToken);
-            newUser.setRefreshToken(refreshToken);
+            newUser.saveAccessToken(accessToken);
+            newUser.saveRefreshToken(refreshToken);
             userRepository.save(newUser);
 
             return new LoginResponse(accessToken, refreshToken);

--- a/src/main/java/com/memesphere/domain/user/service/KakaoServiceImpl.java
+++ b/src/main/java/com/memesphere/domain/user/service/KakaoServiceImpl.java
@@ -77,7 +77,6 @@ public class KakaoServiceImpl implements KakaoService {
             userServiceImpl.save(newUser);
         } else {
             User updatedUser = UserConverter.toUpdatedKakaoUser(kakaoUserInfoResponse, tokenResponse); // 기존 유저 업데이트
-            existingUser.setSocialType(SocialType.KAKAO);
             userServiceImpl.save(updatedUser);
         }
     }
@@ -91,8 +90,8 @@ public class KakaoServiceImpl implements KakaoService {
             accessToken = tokenProvider.createAccessToken(existingUser.getEmail(), existingUser.getLoginId());
             String refreshToken = tokenProvider.createRefreshToken(existingUser.getEmail());
 
-            existingUser.setAccessToken(accessToken);
-            existingUser.setRefreshToken(refreshToken);
+            existingUser.saveAccessToken(accessToken);
+            existingUser.saveRefreshToken(refreshToken);
             userRepository.save(existingUser);
 
             return new LoginResponse(accessToken, refreshToken);
@@ -103,8 +102,8 @@ public class KakaoServiceImpl implements KakaoService {
             accessToken = tokenProvider.createAccessToken(newUser.getEmail(), newUser.getLoginId());
             String refreshToken = tokenProvider.createRefreshToken(newUser.getEmail());
 
-            newUser.setAccessToken(accessToken);
-            newUser.setRefreshToken(refreshToken);
+            newUser.saveAccessToken(accessToken);
+            newUser.saveRefreshToken(refreshToken);
             userRepository.save(newUser);
 
             return new LoginResponse(accessToken, refreshToken);

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -5,6 +5,7 @@
         <title>login</title>
     </head>
     <body>
-        <a th:href="${testLoginUrl}">login</a>
+        <a th:href="${testKakaoLoginUrl}">kakaoLogin</a>
+        <a th:href="${testGoogleLoginUrl}">googleLogin</a>
     </body>
 </html>


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #38 

## 📝작업 내용

- 구글 로그인 구현 
  - 카카오 로그인과 같은 방식으로 프론트로부터 인가코드를 받아와서 토큰을 발급 받아 유저 정보를 받아옵니다.
  - [구글 로그인 관련 참고한 블로그 링크](https://velog.io/@bdd14club/%EB%B0%B1%EC%97%94%EB%93%9C-2.-%EA%B5%AC%EA%B8%80-%EC%86%8C%EC%85%9C-%EB%A1%9C%EA%B7%B8%EC%9D%B8-%EA%B5%AC%ED%98%84%ED%95%98%EA%B8%B0#google-access-token-%EC%9A%94%EC%B2%ADgoogleclient)
   ![image](https://github.com/user-attachments/assets/25ecfc6f-0269-444e-aafd-f0a005dd3250)

- 스웨거 테스트 
  - 이전 카카오 로그인과 마찬가지로 `login.html`에 코드 추가해서 텍스트 클릭시 페이지 리다이렉트되도록 임의로 구현해놨습니다. 이 부분도 프론트 측에서 로그인 구현하면 삭제해놓을게요!

- 디비 확인 

### 스크린샷
![image](https://github.com/user-attachments/assets/a5c6efc4-5ffd-493f-8ed3-00d28dcdc9c3)
