### PR TITLE
#51 Fix: 대시보드 차트 조회 api 로그인 여부 처리

### DIFF
--- a/src/main/java/com/memesphere/domain/collection/service/CollectionQueryServiceImpl.java
+++ b/src/main/java/com/memesphere/domain/collection/service/CollectionQueryServiceImpl.java
@@ -28,6 +28,10 @@ public class CollectionQueryServiceImpl implements CollectionQueryService {
     @Transactional(readOnly = true)
     @Override
     public List<Long> getUserCollectionIds(Long userId) {
+        if (userId == null) {
+
+        }
+
         return collectionRepository.findAllByUserId(userId).stream()
                 .map(Collection::getMemeCoinId)
                 .collect(Collectors.toList());

--- a/src/main/java/com/memesphere/domain/collection/service/CollectionQueryServiceImpl.java
+++ b/src/main/java/com/memesphere/domain/collection/service/CollectionQueryServiceImpl.java
@@ -28,10 +28,6 @@ public class CollectionQueryServiceImpl implements CollectionQueryService {
     @Transactional(readOnly = true)
     @Override
     public List<Long> getUserCollectionIds(Long userId) {
-        if (userId == null) {
-
-        }
-
         return collectionRepository.findAllByUserId(userId).stream()
                 .map(Collection::getMemeCoinId)
                 .collect(Collectors.toList());

--- a/src/main/java/com/memesphere/domain/dashboard/controller/DashboardController.java
+++ b/src/main/java/com/memesphere/domain/dashboard/controller/DashboardController.java
@@ -110,7 +110,7 @@ public class DashboardController {
         // 로그인 여부 처리
         // 로그인 x -> null
         // 로그인 o -> 유저 id
-        Long userId = customUserDetails == null ? null : customUserDetails.getUser().getId();
+        Long userId = (customUserDetails == null) ? null : customUserDetails.getUser().getId();
         return ApiResponse.onSuccess(dashboardQueryService.getChartPage(userId, viewType, sortType, pageNumber));
     }
 }

--- a/src/main/java/com/memesphere/domain/dashboard/controller/DashboardController.java
+++ b/src/main/java/com/memesphere/domain/dashboard/controller/DashboardController.java
@@ -2,6 +2,7 @@ package com.memesphere.domain.dashboard.controller;
 
 import com.memesphere.domain.dashboard.dto.response.DashboardOverviewResponse;
 import com.memesphere.domain.dashboard.service.DashboardQueryService;
+import com.memesphere.domain.user.entity.User;
 import com.memesphere.global.apipayload.ApiResponse;
 import com.memesphere.domain.dashboard.dto.response.DashboardTrendListResponse;
 import com.memesphere.global.jwt.CustomUserDetails;
@@ -13,7 +14,6 @@ import com.memesphere.domain.search.entity.ViewType;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -107,9 +107,10 @@ public class DashboardController {
                                                         @CheckPage @RequestParam(name = "page") Integer page) {
         Integer pageNumber = page - 1;
 
-        Long userId = customUserDetails.getUser().getId();
-
-
+        // 로그인 여부 처리
+        // 로그인 x -> null
+        // 로그인 o -> 유저 id
+        Long userId = customUserDetails == null ? null : customUserDetails.getUser().getId();
         return ApiResponse.onSuccess(dashboardQueryService.getChartPage(userId, viewType, sortType, pageNumber));
     }
 }

--- a/src/main/java/com/memesphere/domain/dashboard/service/DashboardQueryService.java
+++ b/src/main/java/com/memesphere/domain/dashboard/service/DashboardQueryService.java
@@ -5,6 +5,7 @@ import com.memesphere.domain.dashboard.dto.response.DashboardTrendListResponse;
 import com.memesphere.domain.search.dto.response.SearchPageResponse;
 import com.memesphere.domain.search.entity.SortType;
 import com.memesphere.domain.search.entity.ViewType;
+import com.memesphere.domain.user.entity.User;
 
 public interface DashboardQueryService {
     // ** 총 거래량 및 총 개수 ** //

--- a/src/main/java/com/memesphere/domain/dashboard/service/DashboardQueryServiceImpl.java
+++ b/src/main/java/com/memesphere/domain/dashboard/service/DashboardQueryServiceImpl.java
@@ -26,6 +26,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.util.Collections;
 import java.util.List;
 
 @Service
@@ -64,9 +65,11 @@ public class DashboardQueryServiceImpl implements DashboardQueryService {
     // ** 차트 ** //
     @Override
     public SearchPageResponse getChartPage(Long userId, ViewType viewType, SortType sortType, Integer pageNumber) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
-        List<Long> userCollectionIds = collectionQueryService.getUserCollectionIds(user.getId());
+
+        // 로그인 x -> 콜렉션 빈 리스트
+        // 로그인 o -> 콜렉션 유저가 등록한 id 리스트
+        List<Long> userCollectionIds = (userId != null) ?
+                collectionQueryService.getUserCollectionIds(userId) : Collections.emptyList();
 
         int pageSize = switch (viewType) {
             case GRID -> 9;

--- a/src/main/java/com/memesphere/domain/dashboard/service/DashboardQueryServiceImpl.java
+++ b/src/main/java/com/memesphere/domain/dashboard/service/DashboardQueryServiceImpl.java
@@ -68,8 +68,8 @@ public class DashboardQueryServiceImpl implements DashboardQueryService {
 
         // 로그인 x -> 콜렉션 빈 리스트
         // 로그인 o -> 콜렉션 유저가 등록한 id 리스트
-        List<Long> userCollectionIds = (userId != null) ?
-                collectionQueryService.getUserCollectionIds(userId) : Collections.emptyList();
+        List<Long> userCollectionIds = (userId == null) ?
+                Collections.emptyList() : collectionQueryService.getUserCollectionIds(userId);
 
         int pageSize = switch (viewType) {
             case GRID -> 9;


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #51

## 📝작업 내용

> 로그인 안 한 경우는 isCollected 필드가 모두 false로, 로그인 한 경우 그대로

![image](https://github.com/user-attachments/assets/82be698f-eb51-4870-9b04-dc9c0458054e)
로그인 x의 경우, customUserDetails가 null 이므로 
userId null 처리 (로그인 한 경우는 그대로)

![image](https://github.com/user-attachments/assets/79953239-2633-4537-bd08-07bcce483671)
로그인 x의 경우 userId가 null 이므로
userCollectionIds 빈 리스트 처리 (로그인 한 경우는 그대로)

### 스크린샷 (선택)
- 로그인 안 한 경우
![image](https://github.com/user-attachments/assets/8441ee45-a9e3-4b6f-a37f-4b882e099565)
![image](https://github.com/user-attachments/assets/7210a82a-25d2-4046-be9b-54ff8c725881)
![image](https://github.com/user-attachments/assets/d8cbc225-4f33-4b45-90f4-db1b62983c2c)
- 로그인 한 경우
![image](https://github.com/user-attachments/assets/1d8491e8-43da-488d-8060-153fd32d8713)
![image](https://github.com/user-attachments/assets/441d4b29-8204-460b-84b5-71b53b4aabc3)
![image](https://github.com/user-attachments/assets/17c92e94-8e06-4ab7-8667-e489e95b0919)



## 💬리뷰 요구사항(선택)
