### PR TITLE
#58 BugFix: s3 이미지 업로드 방식 수정 (Presigned Url)

### DIFF
--- a/src/main/java/com/memesphere/domain/image/controller/ImageController.java
+++ b/src/main/java/com/memesphere/domain/image/controller/ImageController.java
@@ -1,15 +1,13 @@
 package com.memesphere.domain.image.controller;
 
+import com.memesphere.domain.image.dto.response.PresignedUrlResponse;
+import com.memesphere.domain.image.dto.request.ImageExtensionRequest;
 import com.memesphere.domain.image.service.ImageService;
 import com.memesphere.global.apipayload.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.bind.annotation.*;
 
 import java.io.IOException;
 
@@ -20,12 +18,18 @@ public class ImageController {
 
     private final ImageService imageService;
 
-    @PostMapping(value="/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
-    @Operation(summary = "이미지 Presigned URL 발급",
-            description = "사용자가 이미지를 업로드하고, S3에 저장한 후 해당 이미지에 대한 presigned URL을 발급받습니다. \n" +
-                    "업로드할 파일(JPG, JPEG, PNG만 가능)은 'file'이라는 키로 multipart/form-data 형식으로 첨부해야 합니다.")
-    public ApiResponse<String> uploadFile(@RequestParam("file") MultipartFile file) throws IOException {
-        String url = imageService.uploadFile(file);
+    @PostMapping(value = "/upload", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+    @Operation(
+            summary = "이미지 Presigned URL 발급",
+            description = "업로드할 파일의 확장자(jpg, jpeg, png만 가능)를 전송하면 해당 이미지의 Presigned URL을 발급받습니다. \n" +
+                    "발급된 Presigned URL로 'PUT' 요청을 보내 실제 이미지를 업로드하면, 성공 시 imageUrl이 활성화됩니다.")
+
+            public ApiResponse<PresignedUrlResponse> uploadFile(@RequestBody ImageExtensionRequest request) throws IOException {
+
+        String extension = request.getExtension();
+        // 확장자에 맞는 파일명 생성 및 Presigned URL 생성
+        PresignedUrlResponse url = imageService.uploadFile(extension);
+
         return ApiResponse.onSuccess(url);
     }
 }

--- a/src/main/java/com/memesphere/domain/image/controller/ImageController.java
+++ b/src/main/java/com/memesphere/domain/image/controller/ImageController.java
@@ -9,8 +9,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
 
-import java.io.IOException;
-
 @RequestMapping("/s3")
 @RestController
 @RequiredArgsConstructor
@@ -24,7 +22,7 @@ public class ImageController {
             description = "업로드할 파일의 확장자(jpg, jpeg, png만 가능)를 전송하면 해당 이미지의 Presigned URL을 발급받습니다. \n" +
                     "발급된 Presigned URL로 'PUT' 요청을 보내 실제 이미지를 업로드하면, 성공 시 imageUrl이 활성화됩니다.")
 
-            public ApiResponse<PresignedUrlResponse> uploadFile(@RequestBody ImageExtensionRequest request) throws IOException {
+            public ApiResponse<PresignedUrlResponse> uploadFile(@RequestBody ImageExtensionRequest request) {
 
         String extension = request.getExtension();
         // 확장자에 맞는 파일명 생성 및 Presigned URL 생성

--- a/src/main/java/com/memesphere/domain/image/converter/ImageConverter.java
+++ b/src/main/java/com/memesphere/domain/image/converter/ImageConverter.java
@@ -1,0 +1,14 @@
+package com.memesphere.domain.image.converter;
+
+import com.memesphere.domain.image.dto.response.PresignedUrlResponse;
+
+import java.net.URL;
+
+public class ImageConverter {
+    public static PresignedUrlResponse toPresignedUrlDto(URL presignedUrl, String imageUrl) {
+        return PresignedUrlResponse.builder()
+                .presignedUrl(presignedUrl.toString())
+                .imageUrl(imageUrl)
+                .build();
+    }
+}

--- a/src/main/java/com/memesphere/domain/image/dto/request/ImageExtensionRequest.java
+++ b/src/main/java/com/memesphere/domain/image/dto/request/ImageExtensionRequest.java
@@ -1,0 +1,12 @@
+package com.memesphere.domain.image.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ImageExtensionRequest {
+    private String extension;
+}

--- a/src/main/java/com/memesphere/domain/image/dto/response/PresignedUrlResponse.java
+++ b/src/main/java/com/memesphere/domain/image/dto/response/PresignedUrlResponse.java
@@ -1,0 +1,16 @@
+package com.memesphere.domain.image.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+@Getter
+@Builder
+public class PresignedUrlResponse {
+    @Schema(description = "Presigned URL", example = "https://s3.bucket.com/...") // 예제 추가
+    private String presignedUrl;
+
+    @Schema(description = "Image URL", example = "https://umc..jpg")
+    private String imageUrl;
+
+}
+

--- a/src/main/java/com/memesphere/domain/image/dto/response/PresignedUrlResponse.java
+++ b/src/main/java/com/memesphere/domain/image/dto/response/PresignedUrlResponse.java
@@ -6,7 +6,7 @@ import lombok.*;
 @Getter
 @Builder
 public class PresignedUrlResponse {
-    @Schema(description = "Presigned URL", example = "https://s3.bucket.com/...") // 예제 추가
+    @Schema(description = "Presigned URL", example = "https://s3.bucket.com/...")
     private String presignedUrl;
 
     @Schema(description = "Image URL", example = "https://umc..jpg")

--- a/src/main/java/com/memesphere/domain/image/service/ImageService.java
+++ b/src/main/java/com/memesphere/domain/image/service/ImageService.java
@@ -39,7 +39,7 @@ public class ImageService {
             return ImageConverter.toPresignedUrlDto(presignedUrl, imageUrl);
 
         }  catch (Exception e) {
-            throw new GeneralException(ErrorStatus.FILE_UPLOAD_FAILED);
+            throw new GeneralException(ErrorStatus.PRESIGNED_URL_FAILED);
         }
     }
 

--- a/src/main/java/com/memesphere/domain/image/service/ImageService.java
+++ b/src/main/java/com/memesphere/domain/image/service/ImageService.java
@@ -11,7 +11,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
-import java.io.IOException;
 import java.net.URL;
 import java.util.*;
 
@@ -26,7 +25,7 @@ public class ImageService {
 
     private static final Set<String> ALLOWED_EXTENSIONS = Set.of("jpg", "jpeg", "png");
 
-    public PresignedUrlResponse uploadFile(String extension) throws IOException {
+    public PresignedUrlResponse uploadFile(String extension) {
 
         // 확장자 검사
         validateImageFileExtension(extension);
@@ -81,6 +80,6 @@ public class ImageService {
 
     // 파일명 설정
     private String generateFileName(String extension) {
-        return UUID.randomUUID().toString() + "." + extension;
+        return UUID.randomUUID() + "." + extension;
     }
 }

--- a/src/main/java/com/memesphere/global/apipayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/memesphere/global/apipayload/code/status/ErrorStatus.java
@@ -38,7 +38,7 @@ public enum ErrorStatus implements BaseCode {
 
     // 이미지 에러
     INVALID_FILE_EXTENTION(HttpStatus.BAD_REQUEST, "INVALID FILE EXTENSION", "지원되지 않는 파일 형식입니다."),
-    FILE_UPLOAD_FAILED(HttpStatus.BAD_REQUEST,"FILE UPLOAD FAILED","이미지 업로드를 실패했습니다.");
+    PRESIGNED_URL_FAILED(HttpStatus.BAD_REQUEST, "PRESIGNED URL GENERATION FAILED", "presigned URL 생성에 실패했습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/memesphere/global/apipayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/memesphere/global/apipayload/code/status/ErrorStatus.java
@@ -33,8 +33,9 @@ public enum ErrorStatus implements BaseCode {
     NICKNAME_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "NICKNAME ALREADY EXIST ", "이미 사용 중인 닉네임입니다."),
 
     // 이미지 에러
-    EMPTY_FILE_EXCEPTION(HttpStatus.BAD_REQUEST, "EMPTY_FILE", "이미지가 빈 파일입니다."),
-    INVALID_FILE_EXTENTION(HttpStatus.BAD_REQUEST, "INVALID FILE EXTENSION", "지원되지 않는 파일 형식입니다.");
+    EMPTY_FILE_EXCEPTION(HttpStatus.BAD_REQUEST, "EMPTY FILE", "이미지가 빈 파일입니다."),
+    INVALID_FILE_EXTENTION(HttpStatus.BAD_REQUEST, "INVALID FILE EXTENSION", "지원되지 않는 파일 형식입니다."),
+    FILE_UPLOAD_FAILED(HttpStatus.BAD_REQUEST,"FILE UPLOAD FAILED","이미지 업로드를 실패했습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/memesphere/global/apipayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/memesphere/global/apipayload/code/status/ErrorStatus.java
@@ -37,7 +37,6 @@ public enum ErrorStatus implements BaseCode {
     NICKNAME_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "NICKNAME ALREADY EXIST ", "이미 사용 중인 닉네임입니다."),
 
     // 이미지 에러
-    EMPTY_FILE_EXCEPTION(HttpStatus.BAD_REQUEST, "EMPTY FILE", "이미지가 빈 파일입니다."),
     INVALID_FILE_EXTENTION(HttpStatus.BAD_REQUEST, "INVALID FILE EXTENSION", "지원되지 않는 파일 형식입니다."),
     FILE_UPLOAD_FAILED(HttpStatus.BAD_REQUEST,"FILE UPLOAD FAILED","이미지 업로드를 실패했습니다.");
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #58  

## 📝작업 내용

> 기존 코드에서는 이미지를 서버에서 직접적으로 업로드하는 오류가 있어서, 업로드할 이미지의 확장자만을 서버로 보내면 서버는 그에 따른 presignedUrl과 imageUrl을 발급해주고, 발급받은 presignedUrl로 이미지를 성공적으로 전송할 시 해당 imageUrl을 사용할 수 있는 방식으로 수정했습니다.

![image](https://github.com/user-attachments/assets/9981eb1d-e31e-4ce1-8534-d5c99419d7d1)
![image](https://github.com/user-attachments/assets/b442ec00-2c59-498a-b285-2f705de4f405)
![image](https://github.com/user-attachments/assets/672719ba-b8d8-4af2-851e-623a352b2078)


## 💬리뷰 요구사항(선택)
