### PR TITLE
#59 Feat: 등록한 알림 삭제 API

### DIFF
--- a/src/main/java/com/memesphere/domain/notification/controller/CoinNotificationController.java
+++ b/src/main/java/com/memesphere/domain/notification/controller/CoinNotificationController.java
@@ -102,6 +102,7 @@ public class CoinNotificationController {
                     등록한 알림 조회 API 응답 형식과 동일
                     ```""")
     public ApiResponse<NotificationListResponse> deleteNotification(@PathVariable("notification-id") Long id) {
-        return ApiResponse.onSuccess(coinNotificationService.removeNotification(id));
+        coinNotificationService.removeNotification(id);
+        return ApiResponse.onSuccess(coinNotificationService.findNotificationList());
     }
 }

--- a/src/main/java/com/memesphere/domain/notification/dto/request/NotificationRequest.java
+++ b/src/main/java/com/memesphere/domain/notification/dto/request/NotificationRequest.java
@@ -8,7 +8,7 @@ import lombok.Getter;
 @Builder
 public class NotificationRequest {
 
-    @Schema(description = "코인 이름", example = "DOGE")
+    @Schema(description = "코인 이름", example = "Dogecoin")
     private String name;
 
     @Schema(description = "코인 심볼", example = "DOGE/USDT")

--- a/src/main/java/com/memesphere/domain/notification/service/CoinNotificationServiceImpl.java
+++ b/src/main/java/com/memesphere/domain/notification/service/CoinNotificationServiceImpl.java
@@ -46,7 +46,7 @@ public class CoinNotificationServiceImpl implements CoinNotificationService {
     @Override
     public NotificationResponse addNotification(NotificationRequest notificationRequest) {
         MemeCoin memeCoin = memeCoinRepository.findByName(notificationRequest.getName())
-                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMECOIN_NOT_FOUND));;
+                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMECOIN_NOT_FOUND));
 
         Notification notification = NotificationConverter.toNotification(notificationRequest, memeCoin);
         notificationRepository.save(notification);
@@ -63,6 +63,12 @@ public class CoinNotificationServiceImpl implements CoinNotificationService {
 
     @Override
     public NotificationListResponse removeNotification(Long notificationId) {
+
+        MemeCoin memeCoin = memeCoinRepository.findById(notificationId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMECOIN_NOT_FOUND));
+
+        notificationRepository.deleteById(notificationId);
+
         return null;
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #59 

## 📝작업 내용

- 등록한 알림 삭제 API 구현
- 기존에 지윤님이 작성해주신 `NotificationRequest`에서 예시인 도지코인이 `MEMECOIN_NOT_FOUND `에러가 나서 보니까 이름이 틀린 것 같아서 수정했어요!

### 스크린샷
![image](https://github.com/user-attachments/assets/9b62a4db-1022-46b8-8bde-c791b724ca47)
