### PR TITLE
#86 Fix: 컬렉션 조회 Resonse Body에 coinId 추가

### DIFF
--- a/src/main/java/com/memesphere/domain/collection/converter/CollectionConverter.java
+++ b/src/main/java/com/memesphere/domain/collection/converter/CollectionConverter.java
@@ -38,6 +38,7 @@ public class CollectionConverter {
         ChartData chartData = memeCoin.getChartDataList().get(0);
 
         return CollectionPreviewResponse.builder()
+                .coinId(memeCoin.getId())
                 .name(memeCoin.getName())
                 .symbol(memeCoin.getSymbol())
                 .image(memeCoin.getImage())

--- a/src/main/java/com/memesphere/domain/collection/dto/response/CollectionPreviewResponse.java
+++ b/src/main/java/com/memesphere/domain/collection/dto/response/CollectionPreviewResponse.java
@@ -13,6 +13,8 @@ import java.math.BigDecimal;
 @AllArgsConstructor
 @NoArgsConstructor
 public class CollectionPreviewResponse {
+    @Schema(description = "밈코인 id", example = "1")
+    Long coinId;
     @Schema(description = "밈코인 name", example = "도지코인")
     String name;
     @Schema(description = "밈코인 symbol", example = "DOGE")


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #86

## 📝작업 내용

> 프론트 요청으로 컬렉션 조회 Resonse Body에 coinId 추가했습니당

### 스크린샷
<img width="677" alt="Screenshot 2025-02-11 at 15 13 53" src="https://github.com/user-attachments/assets/54a2bb29-cf03-4262-8689-8f1541b5819d" />
