### PR TITLE
#88 Fix: 구글 로그인 redirect uri 설정

### DIFF
--- a/src/main/java/com/memesphere/domain/user/controller/UserController.java
+++ b/src/main/java/com/memesphere/domain/user/controller/UserController.java
@@ -21,11 +21,13 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.io.IOException;
 
+@Slf4j
 @Tag(name="회원", description = "회원 관련  API")
 @RestController
 @RequestMapping("/user")
@@ -49,8 +51,16 @@ public class UserController {
 
     @PostMapping("/login/oauth2/google")
     @Operation(summary = "구글 로그인/회원가입 API")
-    public ApiResponse<LoginResponse> googleLogin(@RequestParam("code") String code) throws IOException {
-        TokenResponse googleTokenResponse = googleServiceImpl.getAccessTokenFromGoogle(code);
+    public ApiResponse<LoginResponse> googleLogin(HttpServletRequest request, @RequestParam("code") String code) throws IOException {
+        TokenResponse googleTokenResponse = null;
+        String origin = request.getHeader("Origin");
+
+        if(origin.equals("http://localhost:3000") || origin.equals("http://localhost:8080")){
+            googleTokenResponse = googleServiceImpl.getAccessTokenFromGoogle(code, "http://localhost:8080/user/login/oauth2/google");
+        } else if(origin.equals("https://15.164.103.195.nip.io")){
+            googleTokenResponse = googleServiceImpl.getAccessTokenFromGoogle(code, "https://15.164.103.195.nip.io/user/login/oauth2/google");
+        }
+
         GoogleUserInfoResponse googleUserInfoResponse = googleServiceImpl.getUserInfo(googleTokenResponse.getAccessToken());
         LoginResponse loginResponse = googleServiceImpl.handleUserLogin(googleUserInfoResponse);
 

--- a/src/main/java/com/memesphere/domain/user/controller/UserController.java
+++ b/src/main/java/com/memesphere/domain/user/controller/UserController.java
@@ -21,7 +21,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 

--- a/src/main/java/com/memesphere/domain/user/controller/UserController.java
+++ b/src/main/java/com/memesphere/domain/user/controller/UserController.java
@@ -55,9 +55,11 @@ public class UserController {
         TokenResponse googleTokenResponse = null;
         String origin = request.getHeader("Origin");
 
-        if(origin.equals("http://localhost:3000") || origin.equals("http://localhost:8080")){
+        if (origin.equals("http://localhost:3000")) {
+            googleTokenResponse = googleServiceImpl.getAccessTokenFromGoogle(code, "http://localhost:3000/user/login/oauth2/google");
+        } else if (origin.equals("http://localhost:8080")) {
             googleTokenResponse = googleServiceImpl.getAccessTokenFromGoogle(code, "http://localhost:8080/user/login/oauth2/google");
-        } else if(origin.equals("https://15.164.103.195.nip.io")){
+        } else if (origin.equals("https://15.164.103.195.nip.io")) {
             googleTokenResponse = googleServiceImpl.getAccessTokenFromGoogle(code, "https://15.164.103.195.nip.io/user/login/oauth2/google");
         }
 

--- a/src/main/java/com/memesphere/domain/user/controller/UserController.java
+++ b/src/main/java/com/memesphere/domain/user/controller/UserController.java
@@ -27,7 +27,6 @@ import org.springframework.web.bind.annotation.*;
 
 import java.io.IOException;
 
-@Slf4j
 @Tag(name="회원", description = "회원 관련  API")
 @RestController
 @RequestMapping("/user")

--- a/src/main/java/com/memesphere/domain/user/service/GoogleService.java
+++ b/src/main/java/com/memesphere/domain/user/service/GoogleService.java
@@ -5,7 +5,7 @@ import com.memesphere.domain.user.dto.response.LoginResponse;
 import com.memesphere.domain.user.dto.response.TokenResponse;
 
 public interface GoogleService {
-    TokenResponse getAccessTokenFromGoogle(String code);
+    TokenResponse getAccessTokenFromGoogle(String code, String redirectUri);
     GoogleUserInfoResponse getUserInfo(String accessToken);
     LoginResponse handleUserLogin(GoogleUserInfoResponse userInfo);
 }

--- a/src/main/java/com/memesphere/domain/user/service/GoogleServiceImpl.java
+++ b/src/main/java/com/memesphere/domain/user/service/GoogleServiceImpl.java
@@ -33,9 +33,6 @@ public class GoogleServiceImpl implements GoogleService{
     @Value("${security.oauth2.client.registration.google.client-secret}")
     private String clientSecret;
 
-    @Value("${security.oauth2.client.registration.google.redirect-uri}")
-    private String redirectUri;
-
     @Value("${security.oauth2.client.registration.google.authorization-grant-type}")
     private String authorizationCode;
 
@@ -46,7 +43,7 @@ public class GoogleServiceImpl implements GoogleService{
     private String userInfoUri;
 
 
-    public TokenResponse getAccessTokenFromGoogle(String code) {
+    public TokenResponse getAccessTokenFromGoogle(String code, String redirectUri) {
         try {
             String decodedCode = URLDecoder.decode(code, StandardCharsets.UTF_8);
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #88 

## 📝작업 내용

- 구글 로그인 redirect uri 설정

  - 구글 로그인 API 요청에서 Origin 헤더값을 동적으로 가져오는 방식으로 수정하였습니다. 

  - getAccessTokenFromGoogle 메서드에서 redirect_uri를 application.yml에서 가져오는 대신에 Origin에 따라 파라미터로 받아서 설정하도록 수정해서 프론트 로컬과 추후 배포 링크, 백엔드 로컬 모두 로그인 가능하도록 하였습니다.
