### PR TITLE
#112 Feat: 네이버 검색어 트렌드 API

### DIFF
--- a/src/main/java/com/memesphere/domain/naver/controller/SearchTrendController.java
+++ b/src/main/java/com/memesphere/domain/naver/controller/SearchTrendController.java
@@ -1,0 +1,69 @@
+package com.memesphere.domain.naver.controller;
+
+
+import com.memesphere.domain.naver.dto.request.SearchRequest;
+import com.memesphere.domain.naver.dto.response.SearchResponse;
+import com.memesphere.domain.naver.service.SearchTrendService;
+import com.memesphere.global.apipayload.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+
+
+@RestController
+@RequestMapping("/naver")
+@RequiredArgsConstructor
+public class SearchTrendController {
+
+    private final SearchTrendService searchTrendService;
+
+    @ResponseBody
+    @PostMapping("/trends")
+    @Operation(
+            summary = "네이버 검색어 트렌드 조회 API",
+            description = """
+                해당 키워드에 대한 검색량 비율을 제공합니다.
+                groupName은 분류 목적이고, 검색 트렌드는 keywords 기준으로 계산됩니다.
+                아래 예제와 같이 그룹으로 묶어서 한번에 하나 이상의 요청을 보낼 수 있습니다.
+                - `timeUnit` 옵션: `date` (일간) / `week` (주간) / `month` (월간)
+                """
+    )
+    @io.swagger.v3.oas.annotations.parameters.RequestBody(
+            description = "검색 트렌드 요청 데이터",
+            required = true,
+            content = @Content(
+                    mediaType = "application/json",
+                    examples = @ExampleObject(
+                            name = "트렌드 조회 예제",
+                            summary = "검색 트렌드 조회 요청 예제",
+                            value = """
+                {
+                  "startDate": "2025-02-07",
+                  "endDate": "2025-02-13",
+                  "timeUnit": "date",
+                  "keywordGroups": [
+                    {
+                      "groupName": "밈코인",
+                      "keywords": ["도지코인"]
+                    },
+                    {
+                      "groupName": "밈코인",
+                      "keywords": ["시바이누"]
+                    }
+                  ]
+                }
+                """
+                    )
+            )
+    )
+    public ApiResponse<SearchResponse> getSearchTrends(
+            @RequestBody SearchRequest searchRequest
+    ) {
+        SearchResponse response = searchTrendService.getSearchTrends(searchRequest);
+        return ApiResponse.onSuccess(response);
+    }
+}
+

--- a/src/main/java/com/memesphere/domain/naver/dto/request/SearchRequest.java
+++ b/src/main/java/com/memesphere/domain/naver/dto/request/SearchRequest.java
@@ -1,0 +1,35 @@
+package com.memesphere.domain.naver.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class SearchRequest {
+
+    @Schema(description = "조회 기간 시작 날짜", example = "2025-02-07")
+    private String startDate;
+
+    @Schema(description = "조회 기간 종료 날짜", example = "2025-02-14")
+    private String endDate;
+
+    @Schema(description = "구간 단위", example = "date")
+    private String timeUnit;
+
+    @Schema(description = "검색어 그룹")
+    private List<com.memesphere.domain.naver.dto.request.SearchRequest.KeywordGroup> keywordGroups;
+
+    @Getter
+    @Builder
+    public static class KeywordGroup {
+        @Schema(description = "그룹 이름", example = "밈코인")
+        private String groupName;
+
+        @Schema(description = "조회할 검색어", example = "[\"도지코인\"]")
+        private List<String> keywords;
+    }
+}
+

--- a/src/main/java/com/memesphere/domain/naver/dto/response/SearchResponse.java
+++ b/src/main/java/com/memesphere/domain/naver/dto/response/SearchResponse.java
@@ -1,0 +1,41 @@
+package com.memesphere.domain.naver.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class SearchResponse {
+    @Schema(description = "조회 기간 시작 날짜", example = "2025-02-07")
+    private String startDate;
+
+    @Schema(description = "조회 기간 종료 날짜", example = "2025-02-13")
+    private String endDate;
+
+    @Schema(description = "구간 단위", example = "date")
+    private String timeUnit;
+
+    private List<Result> results;
+
+    @Getter
+    @Builder
+    public static class Result {
+        private String title;
+        private List<String> keywords;
+        private List<Data> data;
+
+        @Getter
+        @Builder
+        public static class Data {
+            @Schema(description = "구간별 시작 날짜", example = "2025-02-14")
+            private String period;
+
+            @Schema(description = "구간별 검색량의 상대적 비율", example = "70.2")
+            private double ratio;
+        }
+    }
+}
+

--- a/src/main/java/com/memesphere/domain/naver/service/SearchTrendService.java
+++ b/src/main/java/com/memesphere/domain/naver/service/SearchTrendService.java
@@ -1,0 +1,58 @@
+package com.memesphere.domain.naver.service;
+
+import com.memesphere.domain.naver.dto.request.SearchRequest;
+import com.memesphere.domain.naver.dto.response.SearchResponse;
+import com.memesphere.global.apipayload.code.status.ErrorStatus;
+import com.memesphere.global.apipayload.exception.GeneralException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.HttpServerErrorException;
+import org.springframework.web.client.RestTemplate;
+
+@Service
+@RequiredArgsConstructor
+public class SearchTrendService {
+
+    private final RestTemplate restTemplate;
+
+    @Value("${naver.url}")
+    private String apiUrl;
+
+    @Value("${naver.client-id}")
+    private String clientId;
+
+    @Value("${naver.secret}")
+    private String clientSecret;
+
+    public SearchResponse getSearchTrends(SearchRequest request) {
+        try {
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_JSON);
+            headers.set("X-Naver-Client-Id", clientId);
+            headers.set("X-Naver-Client-Secret", clientSecret);
+
+            HttpEntity<SearchRequest> entity = new HttpEntity<>(request, headers);
+
+            ResponseEntity<SearchResponse> responseEntity = restTemplate.exchange(
+                    apiUrl,
+                    HttpMethod.POST,
+                    entity,
+                    SearchResponse.class
+            );
+
+            return responseEntity.getBody();
+
+        } catch (HttpClientErrorException.BadRequest e) {
+            throw new GeneralException(ErrorStatus.BAD_REQUEST);
+        } catch (HttpClientErrorException.Unauthorized e) {
+            throw new GeneralException(ErrorStatus.KEY_UNAUTHORIZED);
+        } catch (HttpClientErrorException.Forbidden e) {
+            throw new GeneralException(ErrorStatus.API_FORBIDDEN);
+        } catch (HttpServerErrorException e) {
+            throw new GeneralException(ErrorStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+}

--- a/src/main/java/com/memesphere/global/apipayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/memesphere/global/apipayload/code/status/ErrorStatus.java
@@ -55,7 +55,11 @@ public enum ErrorStatus implements BaseCode {
     PRESIGNED_URL_FAILED(HttpStatus.BAD_REQUEST, "PRESIGNED URL GENERATION FAILED", "presigned URL 생성에 실패했습니다."),
 
     // 채팅 에러
-    CHAT_NOT_FOUND(HttpStatus.NOT_FOUND, "CHAT NOT FOUND", "채팅을 찾을 수 없습니다.");
+    CHAT_NOT_FOUND(HttpStatus.NOT_FOUND, "CHAT NOT FOUND", "채팅을 찾을 수 없습니다."),
+
+    // 네이버 api 에러
+    KEY_UNAUTHORIZED(HttpStatus.UNAUTHORIZED,"NAVER 401 ERROR", "인증 실패. 클라이언트 ID 또는 시크릿이 올바르지 않습니다."),
+    API_FORBIDDEN(HttpStatus.FORBIDDEN, "NAVER 403 ERROR","API 호출 횟수를 초과했습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #112 

## 📝작업 내용

> 네이버 검색어 트렌드 API의 OpenAPI 환경 설정  
> 기본적인 검색 요청 구조, 요청 기능 구현   

![image](https://github.com/user-attachments/assets/f70c42fe-7d0f-4137-a49f-1fcdadb6e62a)
![image](https://github.com/user-attachments/assets/9cd869a6-dba9-4385-98ac-310a71fad15f)


## 💬리뷰 요구사항(선택)

> 사실 프론트에서 바로 요청을 보낼 수도 있지만, 현재 상황에서의 업무 분담을 고려하여 기본적인 요청 환경 설정과 요청 구조를 백엔드에서 구현해 하나의 API로 제공했습니다
