### PR TITLE
#115 Fix: 서치 리스트 응답 형식 수정

### DIFF
--- a/src/main/java/com/memesphere/domain/search/converter/SearchConverter.java
+++ b/src/main/java/com/memesphere/domain/search/converter/SearchConverter.java
@@ -62,7 +62,7 @@ public class SearchConverter {
                 .name(memeCoin.getName())
                 .symbol(memeCoin.getSymbol())
                 .currentPrice(chartData.getPrice())
-                .priceChange(chartData.getPriceChangeRate())
+                .priceChangeRate(chartData.getPriceChangeRate())
                 .weightedAveragePrice(chartData.getWeighted_average_price())
                 .volume(chartData.getVolume())
                 .isCollected(isCollected)

--- a/src/main/java/com/memesphere/domain/search/dto/response/SearchListPreviewResponse.java
+++ b/src/main/java/com/memesphere/domain/search/dto/response/SearchListPreviewResponse.java
@@ -26,8 +26,6 @@ public class SearchListPreviewResponse {
     BigDecimal weightedAveragePrice;
     @Schema(description = "차트 데이터의 volume", example = "5")
     BigDecimal volume;
-    @Schema(description = "차트 데이터의 price_change", example = "500")
-    BigDecimal priceChange;
     @Schema(description = "차트 데이터의 price_change_rate", example = "+2.4%")
     BigDecimal priceChangeRate;
     @Schema(description = "collection에 해당 밈코인 유무", example = "true / false")


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #115 

## 📝작업 내용

> 대시보드 차트 데이터 및 검색 api의 서치 리스트 응답 형식 수정했습니다.
> priceChangeRate 가 null값으로 뜨는 문제로 priceChangeRate에 맞는 값으로 수정하고, 
![image](https://github.com/user-attachments/assets/a80383f6-446d-47dd-b038-c2057950ae33) 에 안 쓰이는 priceChange 필드는 삭제했습니다!


### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/2ca98ace-116d-4d1a-9e86-8df7d72e8d33) <- 수정 전
![image](https://github.com/user-attachments/assets/44421b95-4fd1-4c7e-a95e-2c9ede44a718) <- 수정 후 


## 💬리뷰 요구사항(선택)

> 지금 보니까 기존 priceChange 필드에 chartData.getPriceChangeRate()를 넣어서 priceChangeRate가 null로 뜨는 아무것도 아닌 문제였더라구요! 프론트분께서 여쭤보신 문제였는데,, 추후에도 응답 필드 의미 헷갈리실 수 있을 것 같아 **필드명 이름 명확히 하고자 priceChange -> priceChangeRate로 수정했습니다!** <<< 단순히 필드명만 바꿨다고 생각해주세요!
