### PR TITLE
#134 Fix: GRID뷰 페이지당 12개 코인으로 수정

### DIFF
--- a/src/main/java/com/memesphere/domain/collection/service/CollectionQueryServiceImpl.java
+++ b/src/main/java/com/memesphere/domain/collection/service/CollectionQueryServiceImpl.java
@@ -28,7 +28,7 @@ public class CollectionQueryServiceImpl implements CollectionQueryService {
     public Page<Collection> getCollectionPage(Long userId, Integer pageNumber, ViewType viewType, SortType sortType) {
 
         int pageSize = switch (viewType) {
-            case GRID -> 9;
+            case GRID -> 12;
             case LIST -> 20;
             default -> throw new GeneralException(ErrorStatus.UNSUPPORTED_VIEW_TYPE);
         };

--- a/src/main/java/com/memesphere/domain/dashboard/service/DashboardQueryServiceImpl.java
+++ b/src/main/java/com/memesphere/domain/dashboard/service/DashboardQueryServiceImpl.java
@@ -77,7 +77,7 @@ public class DashboardQueryServiceImpl implements DashboardQueryService {
                 Collections.emptyList() : collectionQueryService.getUserCollectionIds(userId);
 
         int pageSize = switch (viewType) {
-            case GRID -> 9;
+            case GRID -> 12;
             case LIST -> 20;
             default -> throw new GeneralException(ErrorStatus.UNSUPPORTED_VIEW_TYPE);
         };

--- a/src/main/java/com/memesphere/domain/search/service/SearchQueryServiceImpl.java
+++ b/src/main/java/com/memesphere/domain/search/service/SearchQueryServiceImpl.java
@@ -26,7 +26,7 @@ public class SearchQueryServiceImpl implements SearchQueryService {
         // sortType --> MKT_CAP, VOLUME_24H, PRICE
 
         int pageSize = switch (viewType) {
-            case GRID -> 9;
+            case GRID -> 12;
             case LIST -> 20;
             default -> throw new GeneralException(ErrorStatus.UNSUPPORTED_VIEW_TYPE);
         };


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #134

## 📝작업 내용

> GRID뷰 페이지당 12개 코인으로 수정 (프론트 요청)
> 대시보드, 검색, 컬렉션에 사용되는 GRID뷰 모두 수정했습니당
